### PR TITLE
added a char* cast at line 95 and solve compilation error

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -92,7 +92,7 @@ namespace matplotlibcpp {
 				// matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
 				// or matplotlib.backends is imported for the first time
 				if (!s_backend.empty()) {
-					PyObject_CallMethod(matplotlib, "use", "s", s_backend.c_str());
+					PyObject_CallMethod(matplotlib, (char *) "use", (char *) "s", s_backend.c_str());
 				}
 
 				PyObject* pymod = PyImport_Import(pyplotname);


### PR DESCRIPTION
../matplotlibcpp.h:95:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
      PyObject_CallMethod(matplotlib, "use", "s", s_backend.c_str());

Perhaps it will save 15 seconds of life to other people.