### PR TITLE
Extra functionality for figure() function and add fignum_exists() function

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -36,6 +36,7 @@ struct _interpreter {
     PyObject *s_python_function_pause;
     PyObject *s_python_function_save;
     PyObject *s_python_function_figure;
+    PyObject *s_python_function_fignum_exists;
     PyObject *s_python_function_plot;
     PyObject *s_python_function_quiver;
     PyObject *s_python_function_semilogx;
@@ -139,6 +140,7 @@ private:
         s_python_function_draw = PyObject_GetAttrString(pymod, "draw");
         s_python_function_pause = PyObject_GetAttrString(pymod, "pause");
         s_python_function_figure = PyObject_GetAttrString(pymod, "figure");
+        s_python_function_fignum_exists = PyObject_GetAttrString(pymod, "fignum_exists");
         s_python_function_plot = PyObject_GetAttrString(pymod, "plot");
         s_python_function_quiver = PyObject_GetAttrString(pymod, "quiver");
         s_python_function_semilogx = PyObject_GetAttrString(pymod, "semilogx");
@@ -171,6 +173,7 @@ private:
             || !s_python_function_draw
             || !s_python_function_pause
             || !s_python_function_figure
+            || !s_python_function_fignum_exists
             || !s_python_function_plot
             || !s_python_function_quiver
             || !s_python_function_semilogx
@@ -202,6 +205,7 @@ private:
             || !PyFunction_Check(s_python_function_draw)
             || !PyFunction_Check(s_python_function_pause)
             || !PyFunction_Check(s_python_function_figure)
+            || !PyFunction_Check(s_python_function_fignum_exists)
             || !PyFunction_Check(s_python_function_plot)
             || !PyFunction_Check(s_python_function_quiver)
             || !PyFunction_Check(s_python_function_semilogx)
@@ -814,6 +818,23 @@ inline long figure(long number = -1)
     Py_DECREF(res);
 
     return figureNumber;
+}
+
+inline bool fignum_exists(long number)
+{
+    // Make sure interpreter is initialised
+    detail::_interpreter::get();
+
+    PyObject *args = PyTuple_New(1);
+    PyTuple_SetItem(args, 0, PyLong_FromLong(number));
+    PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_fignum_exists, args);
+    if(!res) throw std::runtime_error("Call to fignum_exists() failed.");
+
+    bool ret = PyObject_IsTrue(res);
+    Py_DECREF(res);
+    Py_DECREF(args);
+
+    return ret;
 }
 
 inline void figure_size(size_t w, size_t h)

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -787,14 +787,27 @@ bool stem(const std::vector<Numeric>& y, const std::string& format = "")
     return stem(x, y, format);
 }
 
-inline long figure()
+inline long figure(long number = -1)
 {
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
+    PyObject *res;
+    if (number == -1)
+        res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
+    else {
+        assert(number > 0);
+
+        // Make sure interpreter is initialised
+        detail::_interpreter::get();
+
+        PyObject *args = PyTuple_New(1);
+        PyTuple_SetItem(args, 0, PyLong_FromLong(number));
+        res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, args);
+        Py_DECREF(args);
+    }
+
     if(!res) throw std::runtime_error("Call to figure() failed.");
 
     PyObject* num = PyObject_GetAttrString(res, "number");
     if (!num) throw std::runtime_error("Could not get number attribute of figure object");
-
     const long figureNumber = PyLong_AsLong(num);
 
     Py_DECREF(num);

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -787,12 +787,20 @@ bool stem(const std::vector<Numeric>& y, const std::string& format = "")
     return stem(x, y, format);
 }
 
-inline void figure()
+inline long figure()
 {
     PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
     if(!res) throw std::runtime_error("Call to figure() failed.");
 
+    PyObject* num = PyObject_GetAttrString(res, "number");
+    if (!num) throw std::runtime_error("Could not get number attribute of figure object");
+
+    const long figureNumber = PyLong_AsLong(num);
+
+    Py_DECREF(num);
     Py_DECREF(res);
+
+    return figureNumber;
 }
 
 inline void figure_size(size_t w, size_t h)


### PR DESCRIPTION
Hi there. I'm currently working on a project where it would be useful to be able to check whether a given figure is open or not (by figure number), so I've added support for matplotlib's fignum_exists() function. I also added some extra functionality to the figure() function, as at present you can't find out what the number of a newly created figure is (as far as I can tell). So now figure() returns the figure number and I also added an optional argument so you can create a figure with a specified number. I haven't changed the API in a breaking manner though, so existing code using the figure() function will continue to work as before.