### PR TITLE
colorbar

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,56 @@
+# GNU Makefile for matplotlib-cpp examples
+
+PYVER = 3.5m
+INCDIR = /usr/include/python$(PYVER)
+LIBDIR = /usr/lib/python$(PYVER)
+CXXFLAGS = -O2 -Wall -std=c++11 -I$(INCDIR) -L$(LIBDIR) -lpython$(PYVER)
+
+examples = minimal basic modern animation nonblock xkcd quiver bar surface fill_inbetween fill update imshow colorbar
+
+all: $(examples)
+.PHONY: all clean
+
+minimal: minimal.cpp ../matplotlibcpp.h
+	g++ -DWITHOUT_NUMPY $< -o $@ $(CXXFLAGS)
+
+basic: basic.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+modern: modern.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+animation: animation.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+nonblock: nonblock.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+quiver: quiver.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+xkcd: xkcd.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+bar: bar.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+surface: surface.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+colorbar: colorbar.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+fill_inbetween: fill_inbetween.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+fill: fill.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+update: update.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+imshow: imshow.cpp ../matplotlibcpp.h
+	g++ $< -o $@ $(CXXFLAGS)
+
+clean:
+	rm -f $(examples)

--- a/examples/colorbar.cpp
+++ b/examples/colorbar.cpp
@@ -1,0 +1,31 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
+#include <iostream>
+#include "../matplotlibcpp.h"
+
+using namespace std;
+namespace plt = matplotlibcpp;
+
+int main()
+{
+    // Prepare data
+    int ncols = 500, nrows = 300;
+    std::vector<float> z(ncols * nrows);
+    for (int j=0; j<nrows; ++j) {
+        for (int i=0; i<ncols; ++i) {
+            z.at(ncols * j + i) = std::sin(std::hypot(i - ncols/2, j - nrows/2));
+        }
+    }
+
+    const float* zptr = &(z[0]);
+    const int colors = 1;
+
+    plt::title("My matrix");
+    PyObject* mat = plt::imshow(zptr, nrows, ncols, colors);
+    plt::colorbar(mat);
+
+    // Show plots
+    plt::show();
+    plt::close();
+    Py_DECREF(mat);
+}


### PR DESCRIPTION
Simple wrapper for the `colorbar`.
Note that this function requires the pointer of the corresponding colormapped object, *e.g.* the `surface` or `imshow` of interest. Tests with `surface` indicate that returning `res` after it is decremented works, but I'm not sure if that's undefined behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lava/matplotlib-cpp/111)
<!-- Reviewable:end -->
