### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,25 @@
-examples: minimal basic modern animation nonblock xkcd quiver bar surface fill_inbetween fill update imshow
 
-minimal: examples/minimal.cpp matplotlibcpp.h
-	cd examples && g++ -DWITHOUT_NUMPY minimal.cpp -I/usr/include/python2.7 -lpython2.7 -o minimal -std=c++11
+# Use C++11
+CXXFLAGS += -std=c++11
 
-basic: examples/basic.cpp matplotlibcpp.h
-	cd examples && g++ basic.cpp -I/usr/include/python2.7 -lpython2.7 -o basic -std=c++11
+# Default to using system's default version of python
+PYTHON_BIN     ?= python
+PYTHON_CONFIG  := $(PYTHON_BIN)-config
+PYTHON_INCLUDE ?= $(shell $(PYTHON_CONFIG) --includes)
+CXXFLAGS       += $(PYTHON_INCLUDE)
+LDFLAGS        += $(shell $(PYTHON_CONFIG) --libs)
 
-modern: examples/modern.cpp matplotlibcpp.h
-	cd examples && g++ modern.cpp -I/usr/include/python2.7 -lpython2.7 -o modern -std=c++11
+# Either finds numpy or set -DWITHOUT_NUMPY
+CURRENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+CXXFLAGS    += $(shell $(PYTHON_BIN) $(CURRENT_DIR)/numpy_flags.py)
 
-animation: examples/animation.cpp matplotlibcpp.h
-	cd examples && g++ animation.cpp -I/usr/include/python2.7 -lpython2.7 -o animation -std=c++11
+# Assume every *.cpp file is a separate example
+SOURCES     ?= $(wildcard examples/*.cpp)
+EXECUTABLES := $(foreach exec,$(basename $(SOURCES)),$(exec))
 
-nonblock: examples/nonblock.cpp matplotlibcpp.h
-	cd examples && g++ nonblock.cpp -I/usr/include/python2.7 -lpython2.7 -o nonblock -std=c++11
+.PHONY: examples
 
-quiver: examples/quiver.cpp matplotlibcpp.h
-	cd examples && g++ quiver.cpp -I/usr/include/python2.7 -lpython2.7 -o quiver -std=c++11
-
-xkcd: examples/xkcd.cpp matplotlibcpp.h
-	cd examples && g++ xkcd.cpp -I/usr/include/python2.7 -lpython2.7 -o xkcd -std=c++11
-
-bar: examples/bar.cpp matplotlibcpp.h
-	cd examples && g++ bar.cpp -I/usr/include/python2.7 -lpython2.7 -o bar -std=c++11
-
-surface: examples/surface.cpp matplotlibcpp.h
-	cd examples && g++ surface.cpp -I/usr/include/python2.7 -lpython2.7 -o surface -std=c++11
-
-fill_inbetween: examples/fill_inbetween.cpp matplotlibcpp.h
-	cd examples && g++ fill_inbetween.cpp -I/usr/include/python2.7 -lpython2.7 -o fill_inbetween -std=c++11
-
-fill: examples/fill.cpp matplotlibcpp.h
-	cd examples && g++ fill.cpp -I/usr/include/python2.7 -lpython2.7 -o fill -std=c++11
-
-update: examples/update.cpp matplotlibcpp.h
-	cd examples && g++ update.cpp -I/usr/include/python2.7 -lpython2.7 -o update -std=c++11
-
-imshow: examples/imshow.cpp matplotlibcpp.h
-	cd examples && g++ imshow.cpp -I/usr/include/python2.7 -lpython2.7 -o imshow -std=c++11
+examples: $(EXECUTABLES)
 
 clean:
-	rm -f examples/{minimal,basic,modern,animation,nonblock,xkcd,quiver,bar,surface,fill_inbetween,fill,update,imshow}
+	rm -f ${EXECUTABLES}

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ EXECUTABLES := $(foreach exec,$(basename $(SOURCES)),$(exec))
 
 examples: $(EXECUTABLES)
 
+$(EXECUTABLES): %: %.cpp
+	$(CXX) -o $@ $< $(CXXFLAGS) $(LDFLAGS)
+
 clean:
 	rm -f ${EXECUTABLES}

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,14 @@
+animation
+bar
+basic
+fill
+fill_inbetween
+imshow
+minimal
+modern
+nonblock
+quiver
+subplot
+surface
+update
+xkcd

--- a/numpy_flags.py
+++ b/numpy_flags.py
@@ -1,0 +1,12 @@
+from os import path
+
+try:
+    from numpy import __file__ as numpyloc
+
+    # Get numpy directory
+    numpy_dir = path.dirname(numpyloc)
+
+    # Print the result of joining this to core and include
+    print("-I" + path.join(numpy_dir, "core", "include"))
+except:
+    print("-DWITHOUT_NUMPY")


### PR DESCRIPTION
Hi. I just tried and failed to build the examples (gcc couldn't find my numpy headers), so I thought I'd tidy up the Makefile a bit to make it more generic.

Commit summary:
* Use the system version of python by default rather than python2 (overridable with the ``PYTHON_BIN`` environment variable)
* If numpy is installed, find where the headers live and include them, or, if not, add ``-DWITHOUT_NUMPY`` to the build flags
* Remove the boilerplate and just build each *.cpp file in the ``examples`` folder as a separate binary, with the appropriate flags (this also means you can build with clang instead of gcc)
* Add a ``.gitignore`` file for the example executables