### PR TITLE
Added #include "unordered_map" to main header

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <cstdint> // <cstdint> requires c++11 support
 #include <functional>
+#include <unordered_map>
 
 #include <Python.h>
 


### PR DESCRIPTION
Simply following README.md steps produced an error where "unordered_map" types were not found; Fixed by simply including it on the main header file.