### PR TITLE
remove warning from -Werror=conversion

### DIFF
--- a/examples/update.cpp
+++ b/examples/update.cpp
@@ -24,11 +24,11 @@ int main()
     std::vector<double> x, y;
 
     const double w = 0.05;
-    const double a = n/2;
+    const double a = (double)n/2.0;
 
     for (size_t i=0; i<n; i++) {
-        x.push_back(i);
-        y.push_back(a*sin(w*i));
+        x.push_back((double)i);
+        y.push_back(a*sin(w*(double)i));
     }
 
     std::vector<double> xt(2), yt(2);

--- a/examples/xkcd.cpp
+++ b/examples/xkcd.cpp
@@ -10,7 +10,7 @@ int main() {
     std::vector<double> x(t.size());
 
     for(size_t i = 0; i < t.size(); i++) {
-        t[i] = i / 100.0;
+        t[i] = (double)i / 100.0;
         x[i] = sin(2.0 * M_PI * 1.0 * t[i]);
     }
 

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -737,7 +737,7 @@ bool bar(const std::vector<Numeric> &               y,
   using T = typename std::remove_reference<decltype(y)>::type::value_type;
 
   std::vector<T> x;
-  for (std::size_t i = 0; i < y.size(); i++) { x.push_back(i); }
+  for (std::size_t i = 0; i < y.size(); i++) { x.push_back((T)i); }
 
   return bar(x, y, ec, ls, lw, keywords);
 }
@@ -1101,7 +1101,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = (double)i;
+    for(size_t i=0; i<x.size(); ++i) x.at(i) = (Numeric)i;
     return plot(x,y,format);
 }
 
@@ -1109,7 +1109,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::map<std::string, std::string>& keywords)
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = (double)i;
+    for(size_t i=0; i<x.size(); ++i) x.at(i) = (Numeric)i;
     return plot(x,y,keywords);
 }
 
@@ -1117,7 +1117,7 @@ template<typename Numeric>
 bool stem(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for (size_t i = 0; i < x.size(); ++i) x.at(i) = (double)i;
+    for (size_t i = 0; i < x.size(); ++i) x.at(i) = (Numeric)i;
     return stem(x, y, format);
 }
 

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -1101,7 +1101,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
+    for(size_t i=0; i<x.size(); ++i) x.at(i) = (double)i;
     return plot(x,y,format);
 }
 
@@ -1109,7 +1109,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::map<std::string, std::string>& keywords)
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
+    for(size_t i=0; i<x.size(); ++i) x.at(i) = (double)i;
     return plot(x,y,keywords);
 }
 
@@ -1117,7 +1117,7 @@ template<typename Numeric>
 bool stem(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for (size_t i = 0; i < x.size(); ++i) x.at(i) = i;
+    for (size_t i = 0; i < x.size(); ++i) x.at(i) = (double)i;
     return stem(x, y, format);
 }
 
@@ -1406,9 +1406,9 @@ inline void subplot(long nrows, long ncols, long plot_number)
 {
     // construct positional args
     PyObject* args = PyTuple_New(3);
-    PyTuple_SetItem(args, 0, PyFloat_FromDouble(nrows));
-    PyTuple_SetItem(args, 1, PyFloat_FromDouble(ncols));
-    PyTuple_SetItem(args, 2, PyFloat_FromDouble(plot_number));
+    PyTuple_SetItem(args, 0, PyFloat_FromDouble((double)nrows));
+    PyTuple_SetItem(args, 1, PyFloat_FromDouble((double)ncols));
+    PyTuple_SetItem(args, 2, PyFloat_FromDouble((double)plot_number));
 
     PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_subplot, args);
     if(!res) throw std::runtime_error("Call to subplot() failed.");


### PR DESCRIPTION
Some function used PyFloat_FromDouble(num) where num has 'long' type.