### PR TITLE
Additional settings for plot_surface.

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -241,6 +241,40 @@ private:
 
 } // end namespace detail
 
+    struct SettingValue {
+        int type;
+        bool boolValue;
+        string stringValue;
+        float floatValue;
+        int intValue;
+
+    public:
+        static const int String = 0;
+        static const int Bool = 1;
+        static const int Float = 2;
+        static const int Int = 3;
+
+        SettingValue(const bool value) {
+            this->boolValue = value;
+            this->type = SettingValue::Bool;
+        }
+
+        SettingValue(string value) {
+            this->stringValue = value;
+            this->type = SettingValue::String;
+        }
+
+        SettingValue(float value) {
+            this->floatValue = value;
+            this->type = SettingValue::Float;
+        }
+
+        SettingValue(int value) {
+            this->intValue = value;
+            this->type = SettingValue::Int;
+        }
+    };
+
 /// Select the backend
 ///
 /// **NOTE:** This must be called before the first plot command to have
@@ -426,8 +460,8 @@ template <typename Numeric>
 void plot_surface(const std::vector<::std::vector<Numeric>> &x,
                   const std::vector<::std::vector<Numeric>> &y,
                   const std::vector<::std::vector<Numeric>> &z,
-                  const std::map<std::string, std::string> &keywords =
-                      std::map<std::string, std::string>())
+                  const std::map<std::string, SettingValue> &keywords =
+                      std::map<std::string, SettingValue>())
 {
   // We lazily load the modules here the first time this function is called
   // because I'm not sure that we can assume "matplotlib installed" implies
@@ -466,18 +500,26 @@ void plot_surface(const std::vector<::std::vector<Numeric>> &x,
 
   // Build up the kw args.
   PyObject *kwargs = PyDict_New();
-  PyDict_SetItemString(kwargs, "rstride", PyInt_FromLong(1));
-  PyDict_SetItemString(kwargs, "cstride", PyInt_FromLong(1));
 
-  PyObject *python_colormap_coolwarm = PyObject_GetAttrString(
-      detail::_interpreter::get().s_python_colormap, "coolwarm");
-
-  PyDict_SetItemString(kwargs, "cmap", python_colormap_coolwarm);
-
-  for (std::map<std::string, std::string>::const_iterator it = keywords.begin();
+  for (std::map<std::string, SettingValue>::const_iterator it = keywords.begin();
        it != keywords.end(); ++it) {
-    PyDict_SetItemString(kwargs, it->first.c_str(),
-                         PyString_FromString(it->second.c_str()));
+      PyObject *key = PyString_FromString(it->first.c_str());
+      SettingValue value = it->second;
+
+      switch (value.type) {
+          case SettingValue::String:
+              PyDict_SetItem(kwargs, key, PyString_FromString(value.stringValue.c_str()));
+              break;
+          case SettingValue::Float:
+              PyDict_SetItem(kwargs, key, PyFloat_FromDouble(value.floatValue));
+              break;
+          case SettingValue::Int:
+              PyDict_SetItem(kwargs, key, PyInt_FromLong(value.intValue));
+              break;
+          case SettingValue::Bool:
+              PyDict_SetItem(kwargs, key, PyBool_FromLong(value.boolValue));
+              break;
+      }
   }
 
 


### PR DESCRIPTION
I wanted to be able to do more with the surface plot.  What I've done here is add the ability to set different types of settings - boolean, float, int, string - as the additional arguments for the surface plot.  So, this allows you to do things like: 
- set any color map for the surface,
- set the cstride and rstride (i.e. the size of the segments of the surface)
- set line width, type and color for those segments
- set transparency for the surface
- set other things (whatever they are as long as they are of the types I've implemented so far).

The things that can now be set I removed from being hardcoded in the code.

An example of what can now be done is:
```
    map<string, plt::SettingValue> settings;

    settings.insert({"edgecolor", plt::SettingValue(string("black"))});
    settings.insert({"linewidth", plt::SettingValue(2.0f)});
    settings.insert({"linestyle", plt::SettingValue(string("--"))});
    settings.insert({"alpha", plt::SettingValue(0.5f)});
    settings.insert({"rstride", plt::SettingValue(10)});
    settings.insert({"cstride", plt::SettingValue(10)});
    settings.insert({"cmap", plt::SettingValue(string("gist_rainbow"))});

    plt::plot_surface(a, b, c, settings);
    plt::show();
```

Is it just me or is the formatting of the `matplotlibcpp.h` files rather messed up at the moment.  I didn't change this but I think it should be.

Oh, and finally, I'm mainly a Java and clojure programer.  All this C++ stuff is new to me, so please tell me whatever needs to be different to be more idiomatic...