### PR TITLE
Add axhline, contour and spy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EXTRA_FLAGS     += $(shell $(PYTHON_BIN) $(CURDIR)/numpy_flags.py)
 WITHOUT_NUMPY   := $(findstring $(EXTRA_FLAGS), WITHOUT_NUMPY)
 
 # Examples requiring numpy support to compile
-EXAMPLES_NUMPY  := surface colorbar contour
+EXAMPLES_NUMPY  := surface colorbar contour spy
 EXAMPLES        := minimal basic modern animation nonblock xkcd quiver bar \
 	           fill_inbetween fill update subplot2grid lines3d \
                    $(if $(WITHOUT_NUMPY),,$(EXAMPLES_NUMPY))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PYTHON_BIN     ?= python3
 PYTHON_CONFIG  := $(PYTHON_BIN)-config
 PYTHON_INCLUDE ?= $(shell $(PYTHON_CONFIG) --includes)
 EXTRA_FLAGS    := $(PYTHON_INCLUDE)
-# NOTE: Since python3.8, the correct invocation is `python3-config --libs --embed`. 
+# NOTE: Since python3.8, the correct invocation is `python3-config --libs --embed`.
 # So of course the proper way to get python libs for embedding now is to
 # invoke that, check if it crashes, and fall back to just `--libs` if it does.
 LDFLAGS        += $(shell if $(PYTHON_CONFIG) --libs --embed >/dev/null; then $(PYTHON_CONFIG) --libs --embed; else $(PYTHON_CONFIG) --libs; fi)
@@ -16,7 +16,7 @@ EXTRA_FLAGS     += $(shell $(PYTHON_BIN) $(CURDIR)/numpy_flags.py)
 WITHOUT_NUMPY   := $(findstring $(EXTRA_FLAGS), WITHOUT_NUMPY)
 
 # Examples requiring numpy support to compile
-EXAMPLES_NUMPY  := surface colorbar
+EXAMPLES_NUMPY  := surface colorbar contour
 EXAMPLES        := minimal basic modern animation nonblock xkcd quiver bar \
 	           fill_inbetween fill update subplot2grid lines3d \
                    $(if $(WITHOUT_NUMPY),,$(EXAMPLES_NUMPY))

--- a/examples/contour.cpp
+++ b/examples/contour.cpp
@@ -1,0 +1,24 @@
+#include "../matplotlibcpp.h"
+
+#include <cmath>
+
+namespace plt = matplotlibcpp;
+
+int main()
+{
+    std::vector<std::vector<double>> x, y, z;
+    for (double i = -5; i <= 5;  i += 0.25) {
+        std::vector<double> x_row, y_row, z_row;
+        for (double j = -5; j <= 5; j += 0.25) {
+            x_row.push_back(i);
+            y_row.push_back(j);
+            z_row.push_back(::std::sin(::std::hypot(i, j)));
+        }
+        x.push_back(x_row);
+        y.push_back(y_row);
+        z.push_back(z_row);
+    }
+
+    plt::contour(x, y, z);
+    plt::show();
+}

--- a/examples/spy.cpp
+++ b/examples/spy.cpp
@@ -1,0 +1,29 @@
+#import <iostream>
+#import <vector>
+#import "../matplotlibcpp.h"
+
+namespace plt = matplotlibcpp;
+
+int main()
+{
+    const int n = 20;
+    std::vector<std::vector<double>> matrix;
+
+    for (int i = 0; i < n; ++i) {
+        std::vector<double> row;
+        for (int j = 0; j < n; ++j) {
+            if (i == j)
+                row.push_back(-2);
+            else if (j == i - 1 || j == i + 1)
+                row.push_back(1);
+            else
+                row.push_back(0);
+        }
+        matrix.push_back(row);
+    }
+
+    plt::spy(matrix, 5, {{"marker", "o"}});
+    plt::show();
+
+    return 0;
+}

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -94,6 +94,7 @@ struct _interpreter {
     PyObject *s_python_function_bar;
     PyObject *s_python_function_colorbar;
     PyObject *s_python_function_subplots_adjust;
+    PyObject *s_python_function_contour;
 
 
     /* For now, _interpreter is implemented as a singleton since its currently not possible to have
@@ -205,6 +206,7 @@ private:
         s_python_function_subplot = safe_import(pymod, "subplot");
         s_python_function_subplot2grid = safe_import(pymod, "subplot2grid");
         s_python_function_legend = safe_import(pymod, "legend");
+        s_python_function_xlim = safe_import(pymod, "xlim");
         s_python_function_ylim = safe_import(pymod, "ylim");
         s_python_function_title = safe_import(pymod, "title");
         s_python_function_axis = safe_import(pymod, "axis");
@@ -217,7 +219,6 @@ private:
         s_python_function_yticks = safe_import(pymod, "yticks");
         s_python_function_tick_params = safe_import(pymod, "tick_params");
         s_python_function_grid = safe_import(pymod, "grid");
-        s_python_function_xlim = safe_import(pymod, "xlim");
         s_python_function_ion = safe_import(pymod, "ion");
         s_python_function_ginput = safe_import(pymod, "ginput");
         s_python_function_save = safe_import(pylabmod, "savefig");
@@ -232,6 +233,7 @@ private:
         s_python_function_bar = safe_import(pymod,"bar");
         s_python_function_colorbar = PyObject_GetAttrString(pymod, "colorbar");
         s_python_function_subplots_adjust = safe_import(pymod,"subplots_adjust");
+        s_python_function_contour = safe_import(pymod, "contour");
 #ifndef WITHOUT_NUMPY
         s_python_function_imshow = safe_import(pymod, "imshow");
 #endif
@@ -304,10 +306,10 @@ template <> struct select_npy_type<uint64_t> { const static NPY_TYPES type = NPY
 
 // Sanity checks; comment them out or change the numpy type below if you're compiling on
 // a platform where they don't apply
-static_assert(sizeof(long long) == 8);
-template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
-static_assert(sizeof(unsigned long long) == 8);
-template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
+// static_assert(sizeof(long long) == 8);
+// template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
+// static_assert(sizeof(unsigned long long) == 8);
+// template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
 // TODO: add int, long, etc.
 
 template<typename Numeric>
@@ -520,6 +522,49 @@ void plot_surface(const std::vector<::std::vector<Numeric>> &x,
   Py_DECREF(args);
   Py_DECREF(kwargs);
   if (res) Py_DECREF(res);
+}
+
+template <typename Numeric>
+void contour(const std::vector<::std::vector<Numeric>> &x,
+             const std::vector<::std::vector<Numeric>> &y,
+             const std::vector<::std::vector<Numeric>> &z,
+             const std::map<std::string, std::string> &keywords = {})
+{
+  detail::_interpreter::get();
+
+  // using numpy arrays
+  PyObject *xarray = detail::get_2darray(x);
+  PyObject *yarray = detail::get_2darray(y);
+  PyObject *zarray = detail::get_2darray(z);
+
+  // construct positional args
+  PyObject *args = PyTuple_New(3);
+  PyTuple_SetItem(args, 0, xarray);
+  PyTuple_SetItem(args, 1, yarray);
+  PyTuple_SetItem(args, 2, zarray);
+
+  // Build up the kw args.
+  PyObject *kwargs = PyDict_New();
+
+  PyObject *python_colormap_coolwarm = PyObject_GetAttrString(
+      detail::_interpreter::get().s_python_colormap, "coolwarm");
+
+  PyDict_SetItemString(kwargs, "cmap", python_colormap_coolwarm);
+
+  for (std::map<std::string, std::string>::const_iterator it = keywords.begin();
+       it != keywords.end(); ++it) {
+    PyDict_SetItemString(kwargs, it->first.c_str(),
+                         PyString_FromString(it->second.c_str()));
+  }
+
+  PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_contour, args, kwargs);
+  if (!res)
+    throw std::runtime_error("failed contour");
+
+  Py_DECREF(args);
+  Py_DECREF(kwargs);
+  if (res)
+    Py_DECREF(res);
 }
 #endif // WITHOUT_NUMPY
 

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -95,6 +95,7 @@ struct _interpreter {
     PyObject *s_python_function_colorbar;
     PyObject *s_python_function_subplots_adjust;
     PyObject *s_python_function_contour;
+    PyObject *s_python_function_spy;
 
 
     /* For now, _interpreter is implemented as a singleton since its currently not possible to have
@@ -233,9 +234,10 @@ private:
         s_python_function_bar = safe_import(pymod,"bar");
         s_python_function_colorbar = PyObject_GetAttrString(pymod, "colorbar");
         s_python_function_subplots_adjust = safe_import(pymod,"subplots_adjust");
-        s_python_function_contour = safe_import(pymod, "contour");
 #ifndef WITHOUT_NUMPY
+        s_python_function_contour = safe_import(pymod, "contour");
         s_python_function_imshow = safe_import(pymod, "imshow");
+        s_python_function_spy = safe_import(pymod, "spy");
 #endif
         s_python_empty_tuple = PyTuple_New(0);
     }
@@ -306,11 +308,11 @@ template <> struct select_npy_type<uint64_t> { const static NPY_TYPES type = NPY
 
 // Sanity checks; comment them out or change the numpy type below if you're compiling on
 // a platform where they don't apply
-// static_assert(sizeof(long long) == 8);
-// template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
-// static_assert(sizeof(unsigned long long) == 8);
-// template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
-// TODO: add int, long, etc.
+static_assert(sizeof(long long) == 8);
+template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
+static_assert(sizeof(unsigned long long) == 8);
+template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
+TODO: add int, long, etc.
 
 template<typename Numeric>
 PyObject* get_array(const std::vector<Numeric>& v)
@@ -563,8 +565,37 @@ void contour(const std::vector<::std::vector<Numeric>> &x,
 
   Py_DECREF(args);
   Py_DECREF(kwargs);
-  if (res)
-    Py_DECREF(res);
+  if (res) Py_DECREF(res);
+}
+
+template <typename Numeric>
+void spy(const std::vector<::std::vector<Numeric>> &x,
+         const double markersize = -1,  // -1 for default matplotlib size
+         const std::map<std::string, std::string> &keywords = {})
+{
+  detail::_interpreter::get();
+
+  PyObject *xarray = detail::get_2darray(x);
+
+  PyObject *kwargs = PyDict_New();
+  if (markersize != -1) {
+    PyDict_SetItemString(kwargs, "markersize", PyFloat_FromDouble(markersize));
+  }
+  for (std::map<std::string, std::string>::const_iterator it = keywords.begin();
+       it != keywords.end(); ++it) {
+    PyDict_SetItemString(kwargs, it->first.c_str(),
+                         PyString_FromString(it->second.c_str()));
+  }
+
+  PyObject *plot_args = PyTuple_New(1);
+  PyTuple_SetItem(plot_args, 0, xarray);
+
+  PyObject *res = PyObject_Call(
+      detail::_interpreter::get().s_python_function_spy, plot_args, kwargs);
+
+  Py_DECREF(plot_args);
+  Py_DECREF(kwargs);
+  if (res) Py_DECREF(res);
 }
 #endif // WITHOUT_NUMPY
 


### PR DESCRIPTION
### Summary

Add the methods 
* `axhline` (`axvline` already existed)
* `contour` 
* `spy`

Also added example for `contour` and `spy` to show how to use them (and test that they work).