### PR TITLE
Makefile: include ldflags instead of libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ PYTHON_BIN     ?= python3
 PYTHON_CONFIG  := $(PYTHON_BIN)-config
 PYTHON_INCLUDE ?= $(shell $(PYTHON_CONFIG) --includes)
 EXTRA_FLAGS    := $(PYTHON_INCLUDE)
-# NOTE: Since python3.8, the correct invocation is `python3-config --libs --embed`. 
+# NOTE: Since python3.8, the correct invocation is `python3-config --libs --embed`.
 # So of course the proper way to get python libs for embedding now is to
 # invoke that, check if it crashes, and fall back to just `--libs` if it does.
-LDFLAGS        += $(shell if $(PYTHON_CONFIG) --libs --embed >/dev/null; then $(PYTHON_CONFIG) --libs --embed; else $(PYTHON_CONFIG) --libs; fi)
+LDFLAGS        += $(shell if $(PYTHON_CONFIG) --ldflags --embed >/dev/null; then $(PYTHON_CONFIG) --ldflags --embed; else $(PYTHON_CONFIG) --ldflags; fi)
 
 # Either finds numpy or set -DWITHOUT_NUMPY
 EXTRA_FLAGS     += $(shell $(PYTHON_BIN) $(CURDIR)/numpy_flags.py)


### PR DESCRIPTION
### Summary

The Makefile sets the LDFLAGS to `python-config --libs` which does not contain the path to the library (`-L ...`). Using `python-config --ldflags` includes both the linking to library, as the `--libs` option but additionally the path to the library.

While this is probably not an issue for all users, it can get messy with different Python enviroments and/or on Mac. Just adding the `-L` specification should not change anything for users where this path is linked by default but makes life easier for those where it isn't. 🙂 