### PR TITLE
Getting examples out of the way

### DIFF
--- a/examples/animation.cpp
+++ b/examples/animation.cpp
@@ -4,7 +4,7 @@
 
 namespace plt = matplotlibcpp;
 
-int animation() {
+void animation() {
 	int n = 1000;
 	std::vector<double> x, y, z;
 

--- a/examples/animation.cpp
+++ b/examples/animation.cpp
@@ -4,14 +4,13 @@
 
 namespace plt = matplotlibcpp;
 
-int main()
-{
+int animation() {
 	int n = 1000;
 	std::vector<double> x, y, z;
 
-	for(int i=0; i<n; i++) {
-		x.push_back(i*i);
-		y.push_back(sin(2*M_PI*i/360.0));
+	for (int i = 0; i < n; i++) {
+		x.push_back(i * i);
+		y.push_back(sin(2 * M_PI * i / 360.0));
 		z.push_back(log(i));
 
 		if (i % 10 == 0) {
@@ -23,7 +22,7 @@ int main()
 			plt::named_plot("log(x)", x, z);
 
 			// Set x-axis to interval [0,1000000]
-			plt::xlim(0, n*n);
+			plt::xlim(0, n * n);
 
 			// Add graph title
 			plt::title("Sample figure");

--- a/examples/bar.cpp
+++ b/examples/bar.cpp
@@ -5,7 +5,7 @@
 #include "../matplotlibcpp.h"
 namespace plt = matplotlibcpp;
 
-int bar(int argc, char **argv) {
+void bar(int argc, char **argv) {
 	std::vector<int> test_data;
 	for (int i = 0; i < 20; i++) {
 		test_data.push_back(i);

--- a/examples/bar.cpp
+++ b/examples/bar.cpp
@@ -5,14 +5,14 @@
 #include "../matplotlibcpp.h"
 namespace plt = matplotlibcpp;
 
-int main(int argc, char **argv) {
-    std::vector<int> test_data;
-    for (int i = 0; i < 20; i++) {
-        test_data.push_back(i);
-    }
+int bar(int argc, char **argv) {
+	std::vector<int> test_data;
+	for (int i = 0; i < 20; i++) {
+		test_data.push_back(i);
+	}
 
-    plt::bar(test_data);
-    plt::show();
+	plt::bar(test_data);
+	plt::show();
 
-    return (0);
+	return (0);
 }

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -5,7 +5,7 @@
 
 namespace plt = matplotlibcpp;
 
-int basic() {
+void basic() {
 	// Prepare data.
 	int n = 5000;
 	std::vector<double> x(n), y(n), z(n), w(n, 2);

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -5,40 +5,40 @@
 
 namespace plt = matplotlibcpp;
 
-int main() 
-{
-    // Prepare data.
-    int n = 5000;
-    std::vector<double> x(n), y(n), z(n), w(n,2);
-    for(int i=0; i<n; ++i) {
-        x.at(i) = i*i;
-        y.at(i) = sin(2*M_PI*i/360.0);
-        z.at(i) = log(i);
-    }
-    
-    // Set the size of output image = 1200x780 pixels
-    plt::figure_size(1200, 780);
+int basic() {
+	// Prepare data.
+	int n = 5000;
+	std::vector<double> x(n), y(n), z(n), w(n, 2);
+	for (int i = 0; i < n; ++i) {
+		x.at(i) = i * i;
+		y.at(i) = sin(2 * M_PI * i / 360.0);
+		z.at(i) = log(i);
+	}
 
-    // Plot line from given x and y data. Color is selected automatically.
-    plt::plot(x, y);
+	// Set the size of output image = 1200x780 pixels
+	plt::figure_size(1200, 780);
 
-    // Plot a red dashed line from given x and y data.
-    plt::plot(x, w,"r--");
+	// Plot line from given x and y data. Color is selected automatically.
+	plt::plot(x, y);
 
-    // Plot a line whose name will show up as "log(x)" in the legend.
-    plt::named_plot("log(x)", x, z);
+	// Plot a red dashed line from given x and y data.
+	plt::plot(x, w, "r--");
 
-    // Set x-axis to interval [0,1000000]
-    plt::xlim(0, 1000*1000);
+	// Plot a line whose name will show up as "log(x)" in the legend.
+	plt::named_plot("log(x)", x, z);
 
-    // Add graph title
-    plt::title("Sample figure");
+	// Set x-axis to interval [0,1000000]
+	plt::xlim(0, 1000 * 1000);
 
-    // Enable legend.
-    plt::legend();
+	// Add graph title
+	plt::title("Sample figure");
 
-    // save figure
-    const char* filename = "./basic.png";
-    std::cout << "Saving result to " << filename << std::endl;;
-    plt::save(filename);
+	// Enable legend.
+	plt::legend();
+
+	// save figure
+	const char *filename = "./basic.png";
+	std::cout << "Saving result to " << filename << std::endl;
+	;
+	plt::save(filename);
 }

--- a/examples/colorbar.cpp
+++ b/examples/colorbar.cpp
@@ -6,27 +6,26 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    // Prepare data
-    int ncols = 500, nrows = 300;
-    std::vector<float> z(ncols * nrows);
-    for (int j=0; j<nrows; ++j) {
-        for (int i=0; i<ncols; ++i) {
-            z.at(ncols * j + i) = std::sin(std::hypot(i - ncols/2, j - nrows/2));
-        }
-    }
+int colorbar() {
+	// Prepare data
+	int ncols = 500, nrows = 300;
+	std::vector<float> z(ncols * nrows);
+	for (int j = 0; j < nrows; ++j) {
+		for (int i = 0; i < ncols; ++i) {
+			z.at(ncols * j + i) = std::sin(std::hypot(i - ncols / 2, j - nrows / 2));
+		}
+	}
 
-    const float* zptr = &(z[0]);
-    const int colors = 1;
+	const float *zptr = &(z[0]);
+	const int colors = 1;
 
-    plt::title("My matrix");
-    PyObject* mat;
-    plt::imshow(zptr, nrows, ncols, colors, {}, &mat);
-    plt::colorbar(mat);
+	plt::title("My matrix");
+	PyObject *mat;
+	plt::imshow(zptr, nrows, ncols, colors, { }, &mat);
+	plt::colorbar(mat);
 
-    // Show plots
-    plt::show();
-    plt::close();
-    Py_DECREF(mat);
+	// Show plots
+	plt::show();
+	plt::close();
+	Py_DECREF(mat);
 }

--- a/examples/colorbar.cpp
+++ b/examples/colorbar.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int colorbar() {
+void colorbar() {
 	// Prepare data
 	int ncols = 500, nrows = 300;
 	std::vector<float> z(ncols * nrows);

--- a/examples/fill.cpp
+++ b/examples/fill.cpp
@@ -7,29 +7,29 @@ namespace plt = matplotlibcpp;
 
 // Example fill plot taken from:
 // https://matplotlib.org/gallery/misc/fill_spiral.html
-int main() {
-    // Prepare data.
-    vector<double> theta;
-    for (double d = 0; d < 8 * M_PI; d += 0.1)
-        theta.push_back(d);
+int fill() {
+	// Prepare data.
+	vector<double> theta;
+	for (double d = 0; d < 8 * M_PI; d += 0.1)
+		theta.push_back(d);
 
-    const int a = 1;
-    const double b = 0.2;
+	const int a = 1;
+	const double b = 0.2;
 
-    for (double dt = 0; dt < 2 * M_PI; dt += M_PI/2.0) {
-        vector<double> x1, y1, x2, y2;
-        for (double th : theta) {
-            x1.push_back( a*cos(th + dt) * exp(b*th) );
-            y1.push_back( a*sin(th + dt) * exp(b*th) );
+	for (double dt = 0; dt < 2 * M_PI; dt += M_PI / 2.0) {
+		vector<double> x1, y1, x2, y2;
+		for (double th : theta) {
+			x1.push_back(a * cos(th + dt) * exp(b * th));
+			y1.push_back(a * sin(th + dt) * exp(b * th));
 
-            x2.push_back( a*cos(th + dt + M_PI/4.0) * exp(b*th) );
-            y2.push_back( a*sin(th + dt + M_PI/4.0) * exp(b*th) );
-        }
+			x2.push_back(a * cos(th + dt + M_PI / 4.0) * exp(b * th));
+			y2.push_back(a * sin(th + dt + M_PI / 4.0) * exp(b * th));
+		}
 
-        x1.insert(x1.end(), x2.rbegin(), x2.rend());
-        y1.insert(y1.end(), y2.rbegin(), y2.rend());
+		x1.insert(x1.end(), x2.rbegin(), x2.rend());
+		y1.insert(y1.end(), y2.rbegin(), y2.rend());
 
-        plt::fill(x1, y1, {});
-    }
-    plt::show();
+		plt::fill(x1, y1, { });
+	}
+	plt::show();
 }

--- a/examples/fill.cpp
+++ b/examples/fill.cpp
@@ -7,7 +7,7 @@ namespace plt = matplotlibcpp;
 
 // Example fill plot taken from:
 // https://matplotlib.org/gallery/misc/fill_spiral.html
-int fill() {
+void fill() {
 	// Prepare data.
 	vector<double> theta;
 	for (double d = 0; d < 8 * M_PI; d += 0.1)

--- a/examples/fill_inbetween.cpp
+++ b/examples/fill_inbetween.cpp
@@ -6,23 +6,23 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main() {
-  // Prepare data.
-  int n = 5000;
-  std::vector<double> x(n), y(n), z(n), w(n, 2);
-  for (int i = 0; i < n; ++i) {
-    x.at(i) = i * i;
-    y.at(i) = sin(2 * M_PI * i / 360.0);
-    z.at(i) = log(i);
-  }
+int fill_inbetween() {
+	// Prepare data.
+	int n = 5000;
+	std::vector<double> x(n), y(n), z(n), w(n, 2);
+	for (int i = 0; i < n; ++i) {
+		x.at(i) = i * i;
+		y.at(i) = sin(2 * M_PI * i / 360.0);
+		z.at(i) = log(i);
+	}
 
-  // Prepare keywords to pass to PolyCollection. See
-  // https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.fill_between.html
-  std::map<string, string> keywords;
-  keywords["alpha"] = "0.4";
-  keywords["color"] = "grey";
-  keywords["hatch"] = "-";
+	// Prepare keywords to pass to PolyCollection. See
+	// https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.fill_between.html
+	std::map<string, string> keywords;
+	keywords["alpha"] = "0.4";
+	keywords["color"] = "grey";
+	keywords["hatch"] = "-";
 
-  plt::fill_between(x, y, z, keywords);
-  plt::show();
+	plt::fill_between(x, y, z, keywords);
+	plt::show();
 }

--- a/examples/fill_inbetween.cpp
+++ b/examples/fill_inbetween.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int fill_inbetween() {
+void fill_inbetween() {
 	// Prepare data.
 	int n = 5000;
 	std::vector<double> x(n), y(n), z(n), w(n, 2);

--- a/examples/imshow.cpp
+++ b/examples/imshow.cpp
@@ -6,7 +6,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int imshow() {
+void imshow() {
 	// Prepare data
 	int ncols = 500, nrows = 300;
 	std::vector<float> z(ncols * nrows);

--- a/examples/imshow.cpp
+++ b/examples/imshow.cpp
@@ -6,24 +6,23 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    // Prepare data
-    int ncols = 500, nrows = 300;
-    std::vector<float> z(ncols * nrows);
-    for (int j=0; j<nrows; ++j) {
-        for (int i=0; i<ncols; ++i) {
-            z.at(ncols * j + i) = std::sin(std::hypot(i - ncols/2, j - nrows/2));
-        }
-    }
+int imshow() {
+	// Prepare data
+	int ncols = 500, nrows = 300;
+	std::vector<float> z(ncols * nrows);
+	for (int j = 0; j < nrows; ++j) {
+		for (int i = 0; i < ncols; ++i) {
+			z.at(ncols * j + i) = std::sin(std::hypot(i - ncols / 2, j - nrows / 2));
+		}
+	}
 
-    const float* zptr = &(z[0]);
-    const int colors = 1;
+	const float *zptr = &(z[0]);
+	const int colors = 1;
 
-    plt::title("My matrix");
-    plt::imshow(zptr, nrows, ncols, colors);
+	plt::title("My matrix");
+	plt::imshow(zptr, nrows, ncols, colors);
 
-    // Show plots
-    plt::save("imshow.png");
-    std::cout << "Result saved to 'imshow.png'.\n";
+	// Show plots
+	plt::save("imshow.png");
+	std::cout << "Result saved to 'imshow.png'.\n";
 }

--- a/examples/lines3d.cpp
+++ b/examples/lines3d.cpp
@@ -4,27 +4,27 @@
 
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    std::vector<double> x, y, z;
-    double theta, r;
-    double z_inc = 4.0/99.0; double theta_inc = (8.0 * M_PI)/99.0;
-    
-    for (double i = 0; i < 100; i += 1) {
-        theta = -4.0 * M_PI + theta_inc*i;
-        z.push_back(-2.0 + z_inc*i);
-        r = z[i]*z[i] + 1;
-        x.push_back(r * sin(theta));
-        y.push_back(r * cos(theta));
-    }
+int lines3d() {
+	std::vector<double> x, y, z;
+	double theta, r;
+	double z_inc = 4.0 / 99.0;
+	double theta_inc = (8.0 * M_PI) / 99.0;
 
-    std::map<std::string, std::string> keywords;
-    keywords.insert(std::pair<std::string, std::string>("label", "parametric curve") );
+	for (double i = 0; i < 100; i += 1) {
+		theta = -4.0 * M_PI + theta_inc * i;
+		z.push_back(-2.0 + z_inc * i);
+		r = z[i] * z[i] + 1;
+		x.push_back(r * sin(theta));
+		y.push_back(r * cos(theta));
+	}
 
-    plt::plot3(x, y, z, keywords);
-    plt::xlabel("x label");
-    plt::ylabel("y label");
-    plt::set_zlabel("z label"); // set_zlabel rather than just zlabel, in accordance with the Axes3D method
-    plt::legend();
-    plt::show();
+	std::map<std::string, std::string> keywords;
+	keywords.insert(std::pair<std::string, std::string>("label", "parametric curve"));
+
+	plt::plot3(x, y, z, keywords);
+	plt::xlabel("x label");
+	plt::ylabel("y label");
+	plt::set_zlabel("z label"); // set_zlabel rather than just zlabel, in accordance with the Axes3D method
+	plt::legend();
+	plt::show();
 }

--- a/examples/lines3d.cpp
+++ b/examples/lines3d.cpp
@@ -4,7 +4,7 @@
 
 namespace plt = matplotlibcpp;
 
-int lines3d() {
+void lines3d() {
 	std::vector<double> x, y, z;
 	double theta, r;
 	double z_inc = 4.0 / 99.0;

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -2,7 +2,7 @@
 
 namespace plt = matplotlibcpp;
 
-int minimal() {
+void minimal() {
 	plt::plot( { 1, 3, 2, 4 });
 	plt::show();
 }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -2,7 +2,7 @@
 
 namespace plt = matplotlibcpp;
 
-int main() {
-    plt::plot({1,3,2,4});
-    plt::show();
+int minimal() {
+	plt::plot( { 1, 3, 2, 4 });
+	plt::show();
 }

--- a/examples/modern.cpp
+++ b/examples/modern.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int modern() {
+void modern() {
 	// plot(y) - the x-coordinates are implicitly set to [0,1,...,n)
 	//plt::plot({1,2,3,4});
 

--- a/examples/modern.cpp
+++ b/examples/modern.cpp
@@ -5,25 +5,25 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main() 
-{
+int modern() {
 	// plot(y) - the x-coordinates are implicitly set to [0,1,...,n)
-	//plt::plot({1,2,3,4}); 
-	
+	//plt::plot({1,2,3,4});
+
 	// Prepare data for parametric plot.
 	int n = 5000; // number of data points
-	vector<double> x(n),y(n); 
-	for(int i=0; i<n; ++i) {
-		double t = 2*M_PI*i/n;
-		x.at(i) = 16*sin(t)*sin(t)*sin(t);
-		y.at(i) = 13*cos(t) - 5*cos(2*t) - 2*cos(3*t) - cos(4*t);
+	vector<double> x(n), y(n);
+	for (int i = 0; i < n; ++i) {
+		double t = 2 * M_PI * i / n;
+		x.at(i) = 16 * sin(t) * sin(t) * sin(t);
+		y.at(i) = 13 * cos(t) - 5 * cos(2 * t) - 2 * cos(3 * t) - cos(4 * t);
 	}
 
-	// plot() takes an arbitrary number of (x,y,format)-triples. 
+	// plot() takes an arbitrary number of (x,y,format)-triples.
 	// x must be iterable (that is, anything providing begin(x) and end(x)),
-	// y must either be callable (providing operator() const) or iterable. 
-	plt::plot(x, y, "r-", x, [](double d) { return 12.5+abs(sin(d)); }, "k-");
-
+	// y must either be callable (providing operator() const) or iterable.
+	plt::plot(x, y, "r-", x, [](double d) {
+		return 12.5 + abs(sin(d));
+	}, "k-");
 
 	// show plots
 	plt::show();

--- a/examples/nonblock.cpp
+++ b/examples/nonblock.cpp
@@ -7,7 +7,7 @@ namespace plt = matplotlibcpp;
 using namespace matplotlibcpp;
 using namespace std;
 
-int nonblock() {
+void nonblock() {
 	// Prepare data.
 	int n = 5000;
 	std::vector<double> x(n), y(n), z(n), w(n, 2);

--- a/examples/nonblock.cpp
+++ b/examples/nonblock.cpp
@@ -4,43 +4,41 @@
 
 namespace plt = matplotlibcpp;
 
-
 using namespace matplotlibcpp;
 using namespace std;
 
-int main()
-{
-    // Prepare data.
-    int n = 5000;
-    std::vector<double> x(n), y(n), z(n), w(n,2);
-    for(int i=0; i<n; ++i) {
-        x.at(i) = i*i;
-        y.at(i) = sin(2*M_PI*i/360.0);
-        z.at(i) = log(i);
-    }
+int nonblock() {
+	// Prepare data.
+	int n = 5000;
+	std::vector<double> x(n), y(n), z(n), w(n, 2);
+	for (int i = 0; i < n; ++i) {
+		x.at(i) = i * i;
+		y.at(i) = sin(2 * M_PI * i / 360.0);
+		z.at(i) = log(i);
+	}
 
-    // Plot line from given x and y data. Color is selected automatically.
-    plt::subplot(2,2,1);
-    plt::plot(x, y);
+	// Plot line from given x and y data. Color is selected automatically.
+	plt::subplot(2, 2, 1);
+	plt::plot(x, y);
 
-    // Plot a red dashed line from given x and y data.
-    plt::subplot(2,2,2);
-    plt::plot(x, w,"r--");
+	// Plot a red dashed line from given x and y data.
+	plt::subplot(2, 2, 2);
+	plt::plot(x, w, "r--");
 
-    // Plot a line whose name will show up as "log(x)" in the legend.
-    plt::subplot(2,2,3);
-    plt::named_plot("log(x)", x, z);
+	// Plot a line whose name will show up as "log(x)" in the legend.
+	plt::subplot(2, 2, 3);
+	plt::named_plot("log(x)", x, z);
 
-    // Set x-axis to interval [0,1000000]
-    plt::xlim(0, 1000*1000);
+	// Set x-axis to interval [0,1000000]
+	plt::xlim(0, 1000 * 1000);
 
-    // Add graph title
-    plt::title("Sample figure");
-    // Enable legend.
-    plt::legend();
+	// Add graph title
+	plt::title("Sample figure");
+	// Enable legend.
+	plt::legend();
 
-    plt::show(false);
+	plt::show(false);
 
-    cout << "matplotlibcpp::show() is working in an non-blocking mode" << endl;
-    getchar();
+	cout << "matplotlibcpp::show() is working in an non-blocking mode" << endl;
+	getchar();
 }

--- a/examples/quiver.cpp
+++ b/examples/quiver.cpp
@@ -2,7 +2,7 @@
 
 namespace plt = matplotlibcpp;
 
-int quiver() {
+void quiver() {
 	// u and v are respectively the x and y components of the arrows we're plotting
 	std::vector<int> x, y, u, v;
 	for (int i = -5; i <= 5; i++) {

--- a/examples/quiver.cpp
+++ b/examples/quiver.cpp
@@ -2,19 +2,18 @@
 
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    // u and v are respectively the x and y components of the arrows we're plotting
-    std::vector<int> x, y, u, v;
-    for (int i = -5; i <= 5; i++) {
-        for (int j = -5; j <= 5; j++) {
-            x.push_back(i);
-            u.push_back(-i);
-            y.push_back(j);
-            v.push_back(-j);
-        }
-    }
+int quiver() {
+	// u and v are respectively the x and y components of the arrows we're plotting
+	std::vector<int> x, y, u, v;
+	for (int i = -5; i <= 5; i++) {
+		for (int j = -5; j <= 5; j++) {
+			x.push_back(i);
+			u.push_back(-i);
+			y.push_back(j);
+			v.push_back(-j);
+		}
+	}
 
-    plt::quiver(x, y, u, v);
-    plt::show();
+	plt::quiver(x, y, u, v);
+	plt::show();
 }

--- a/examples/subplot.cpp
+++ b/examples/subplot.cpp
@@ -5,26 +5,24 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main() 
-{
-    // Prepare data
+int subplot() {
+	// Prepare data
 	int n = 500;
-	std::vector<double> x(n), y(n), z(n), w(n,2);
-	for(int i=0; i<n; ++i) {
+	std::vector<double> x(n), y(n), z(n), w(n, 2);
+	for (int i = 0; i < n; ++i) {
 		x.at(i) = i;
-		y.at(i) = sin(2*M_PI*i/360.0);
+		y.at(i) = sin(2 * M_PI * i / 360.0);
 		z.at(i) = 100.0 / i;
 	}
 
-    // Set the "super title"
-    plt::suptitle("My plot");
-    plt::subplot(1, 2, 1);
+	// Set the "super title"
+	plt::suptitle("My plot");
+	plt::subplot(1, 2, 1);
 	plt::plot(x, y, "r-");
-    plt::subplot(1, 2, 2);
-    plt::plot(x, z, "k-");
-    // Add some text to the plot
-    plt::text(100, 90, "Hello!");
-
+	plt::subplot(1, 2, 2);
+	plt::plot(x, z, "k-");
+	// Add some text to the plot
+	plt::text(100, 90, "Hello!");
 
 	// Show plots
 	plt::show();

--- a/examples/subplot.cpp
+++ b/examples/subplot.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int subplot() {
+void subplot() {
 	// Prepare data
 	int n = 500;
 	std::vector<double> x(n), y(n), z(n), w(n, 2);

--- a/examples/subplot2grid.cpp
+++ b/examples/subplot2grid.cpp
@@ -5,40 +5,38 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    // Prepare data
+int subplot2grid() {
+	// Prepare data
 	int n = 500;
 	std::vector<double> x(n), u(n), v(n), w(n);
-	for(int i=0; i<n; ++i) {
+	for (int i = 0; i < n; ++i) {
 		x.at(i) = i;
-		u.at(i) = sin(2*M_PI*i/500.0);
+		u.at(i) = sin(2 * M_PI * i / 500.0);
 		v.at(i) = 100.0 / i;
-		w.at(i) = sin(2*M_PI*i/1000.0);
+		w.at(i) = sin(2 * M_PI * i / 1000.0);
 	}
 
-    // Set the "super title"
-    plt::suptitle("My plot");
+	// Set the "super title"
+	plt::suptitle("My plot");
 
-    const long nrows=3, ncols=3;
-    long row = 2, col = 2;
+	const long nrows = 3, ncols = 3;
+	long row = 2, col = 2;
 
-    plt::subplot2grid(nrows, ncols, row, col);
+	plt::subplot2grid(nrows, ncols, row, col);
 	plt::plot(x, w, "g-");
 
-    long spanr = 1, spanc = 2;
-    col = 0;
-    plt::subplot2grid(nrows, ncols, row, col, spanr, spanc);
+	long spanr = 1, spanc = 2;
+	col = 0;
+	plt::subplot2grid(nrows, ncols, row, col, spanr, spanc);
 	plt::plot(x, v, "r-");
 
-    spanr = 2, spanc = 3;
-    row = 0, col = 0;
-    plt::subplot2grid(nrows, ncols, row, col, spanr, spanc);
-    plt::plot(x, u, "b-");
-    // Add some text to the plot
-    plt::text(100., -0.5, "Hello!");
+	spanr = 2, spanc = 3;
+	row = 0, col = 0;
+	plt::subplot2grid(nrows, ncols, row, col, spanr, spanc);
+	plt::plot(x, u, "b-");
+	// Add some text to the plot
+	plt::text(100., -0.5, "Hello!");
 
-
-    // Show plots
+	// Show plots
 	plt::show();
 }

--- a/examples/subplot2grid.cpp
+++ b/examples/subplot2grid.cpp
@@ -5,7 +5,7 @@
 using namespace std;
 namespace plt = matplotlibcpp;
 
-int subplot2grid() {
+void subplot2grid() {
 	// Prepare data
 	int n = 500;
 	std::vector<double> x(n), u(n), v(n), w(n);

--- a/examples/surface.cpp
+++ b/examples/surface.cpp
@@ -4,7 +4,7 @@
 
 namespace plt = matplotlibcpp;
 
-int surface() {
+void surface() {
 	std::vector<std::vector<double>> x, y, z;
 	for (double i = -5; i <= 5; i += 0.25) {
 		std::vector<double> x_row, y_row, z_row;

--- a/examples/surface.cpp
+++ b/examples/surface.cpp
@@ -4,21 +4,20 @@
 
 namespace plt = matplotlibcpp;
 
-int main()
-{
-    std::vector<std::vector<double>> x, y, z;
-    for (double i = -5; i <= 5;  i += 0.25) {
-        std::vector<double> x_row, y_row, z_row;
-        for (double j = -5; j <= 5; j += 0.25) {
-            x_row.push_back(i);
-            y_row.push_back(j);
-            z_row.push_back(::std::sin(::std::hypot(i, j)));
-        }
-        x.push_back(x_row);
-        y.push_back(y_row);
-        z.push_back(z_row);
-    }
+int surface() {
+	std::vector<std::vector<double>> x, y, z;
+	for (double i = -5; i <= 5; i += 0.25) {
+		std::vector<double> x_row, y_row, z_row;
+		for (double j = -5; j <= 5; j += 0.25) {
+			x_row.push_back(i);
+			y_row.push_back(j);
+			z_row.push_back(::std::sin(::std::hypot(i, j)));
+		}
+		x.push_back(x_row);
+		y.push_back(y_row);
+		z.push_back(z_row);
+	}
 
-    plt::plot_surface(x, y, z);
-    plt::show();
+	plt::plot_surface(x, y, z);
+	plt::show();
 }

--- a/examples/update.cpp
+++ b/examples/update.cpp
@@ -5,56 +5,52 @@
 
 namespace plt = matplotlibcpp;
 
-void update_window(const double x, const double y, const double t,
-                   std::vector<double> &xt, std::vector<double> &yt)
-{
-    const double target_length = 300;
-    const double half_win = (target_length/(2.*sqrt(1.+t*t)));
+void update_window(const double x, const double y, const double t, std::vector<double> &xt, std::vector<double> &yt) {
+	const double target_length = 300;
+	const double half_win = (target_length / (2. * sqrt(1. + t * t)));
 
-    xt[0] = x - half_win;
-    xt[1] = x + half_win;
-    yt[0] = y - half_win*t;
-    yt[1] = y + half_win*t;
+	xt[0] = x - half_win;
+	xt[1] = x + half_win;
+	yt[0] = y - half_win * t;
+	yt[1] = y + half_win * t;
 }
 
+int update() {
+	size_t n = 1000;
+	std::vector<double> x, y;
 
-int main()
-{
-    size_t n = 1000;
-    std::vector<double> x, y;
+	const double w = 0.05;
+	const double a = n / 2;
 
-    const double w = 0.05;
-    const double a = n/2;
+	for (size_t i = 0; i < n; i++) {
+		x.push_back(i);
+		y.push_back(a * sin(w * i));
+	}
 
-    for (size_t i=0; i<n; i++) {
-        x.push_back(i);
-        y.push_back(a*sin(w*i));
-    }
+	std::vector<double> xt(2), yt(2);
 
-    std::vector<double> xt(2), yt(2);
+	plt::title("Tangent of a sine curve");
+	plt::xlim(x.front(), x.back());
+	plt::ylim(-a, a);
+	plt::axis("equal");
 
-    plt::title("Tangent of a sine curve");
-    plt::xlim(x.front(), x.back());
-    plt::ylim(-a, a);
-    plt::axis("equal");
+	// Plot sin once and for all.
+	plt::named_plot("sin", x, y);
 
-    // Plot sin once and for all.
-    plt::named_plot("sin", x, y);
+	// Prepare plotting the tangent.
+	plt::Plot plot("tangent");
 
-    // Prepare plotting the tangent.
-    plt::Plot plot("tangent");
+	plt::legend();
 
-    plt::legend();
+	for (size_t i = 0; i < n; i++) {
+		if (i % 10 == 0) {
+			update_window(x[i], y[i], a * w * cos(w * x[i]), xt, yt);
 
-    for (size_t i=0; i<n; i++) {
-        if (i % 10 == 0) {
-            update_window(x[i], y[i], a*w*cos(w*x[i]), xt, yt);
+			// Just update data for this plot.
+			plot.update(xt, yt);
 
-            // Just update data for this plot.
-            plot.update(xt, yt);
-
-            // Small pause so the viewer has a chance to enjoy the animation.
-            plt::pause(0.1);
-        }
-   }
+			// Small pause so the viewer has a chance to enjoy the animation.
+			plt::pause(0.1);
+		}
+	}
 }

--- a/examples/xkcd.cpp
+++ b/examples/xkcd.cpp
@@ -5,18 +5,18 @@
 
 namespace plt = matplotlibcpp;
 
-int main() {
-    std::vector<double> t(1000);
-    std::vector<double> x(t.size());
+int xkcd() {
+	std::vector<double> t(1000);
+	std::vector<double> x(t.size());
 
-    for(size_t i = 0; i < t.size(); i++) {
-        t[i] = i / 100.0;
-        x[i] = sin(2.0 * M_PI * 1.0 * t[i]);
-    }
+	for (size_t i = 0; i < t.size(); i++) {
+		t[i] = i / 100.0;
+		x[i] = sin(2.0 * M_PI * 1.0 * t[i]);
+	}
 
-    plt::xkcd();
-    plt::plot(t, x);
-    plt::title("AN ORDINARY SIN WAVE");
-    plt::show();
+	plt::xkcd();
+	plt::plot(t, x);
+	plt::title("AN ORDINARY SIN WAVE");
+	plt::show();
 }
 

--- a/examples/xkcd.cpp
+++ b/examples/xkcd.cpp
@@ -5,7 +5,7 @@
 
 namespace plt = matplotlibcpp;
 
-int xkcd() {
+void xkcd() {
 	std::vector<double> t(1000);
 	std::vector<double> x(t.size());
 

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -38,87 +38,84 @@
 #  define PyString_FromString PyUnicode_FromString
 #endif
 
-
 namespace matplotlibcpp {
-namespace detail {
+	namespace detail {
 
-static std::string s_backend;
+		static std::string s_backend;
 
-struct _interpreter {
-    PyObject *s_python_function_show;
-    PyObject *s_python_function_close;
-    PyObject *s_python_function_draw;
-    PyObject *s_python_function_pause;
-    PyObject *s_python_function_save;
-    PyObject *s_python_function_figure;
-    PyObject *s_python_function_fignum_exists;
-    PyObject *s_python_function_plot;
-    PyObject *s_python_function_quiver;
-    PyObject *s_python_function_semilogx;
-    PyObject *s_python_function_semilogy;
-    PyObject *s_python_function_loglog;
-    PyObject *s_python_function_fill;
-    PyObject *s_python_function_fill_between;
-    PyObject *s_python_function_hist;
-    PyObject *s_python_function_imshow;
-    PyObject *s_python_function_scatter;
-    PyObject *s_python_function_boxplot;
-    PyObject *s_python_function_subplot;
-    PyObject *s_python_function_subplot2grid;
-    PyObject *s_python_function_legend;
-    PyObject *s_python_function_xlim;
-    PyObject *s_python_function_ion;
-    PyObject *s_python_function_ginput;
-    PyObject *s_python_function_ylim;
-    PyObject *s_python_function_title;
-    PyObject *s_python_function_axis;
-    PyObject *s_python_function_axvline;
-    PyObject *s_python_function_xlabel;
-    PyObject *s_python_function_ylabel;
-    PyObject *s_python_function_gca;
-    PyObject *s_python_function_xticks;
-    PyObject *s_python_function_yticks;
-    PyObject *s_python_function_tick_params;
-    PyObject *s_python_function_grid;
-    PyObject *s_python_function_clf;
-    PyObject *s_python_function_errorbar;
-    PyObject *s_python_function_annotate;
-    PyObject *s_python_function_tight_layout;
-    PyObject *s_python_colormap;
-    PyObject *s_python_empty_tuple;
-    PyObject *s_python_function_stem;
-    PyObject *s_python_function_xkcd;
-    PyObject *s_python_function_text;
-    PyObject *s_python_function_suptitle;
-    PyObject *s_python_function_bar;
-    PyObject *s_python_function_colorbar;
-    PyObject *s_python_function_subplots_adjust;
+		struct _interpreter {
+				PyObject *s_python_function_show;
+				PyObject *s_python_function_close;
+				PyObject *s_python_function_draw;
+				PyObject *s_python_function_pause;
+				PyObject *s_python_function_save;
+				PyObject *s_python_function_figure;
+				PyObject *s_python_function_fignum_exists;
+				PyObject *s_python_function_plot;
+				PyObject *s_python_function_quiver;
+				PyObject *s_python_function_semilogx;
+				PyObject *s_python_function_semilogy;
+				PyObject *s_python_function_loglog;
+				PyObject *s_python_function_fill;
+				PyObject *s_python_function_fill_between;
+				PyObject *s_python_function_hist;
+				PyObject *s_python_function_imshow;
+				PyObject *s_python_function_scatter;
+				PyObject *s_python_function_boxplot;
+				PyObject *s_python_function_subplot;
+				PyObject *s_python_function_subplot2grid;
+				PyObject *s_python_function_legend;
+				PyObject *s_python_function_xlim;
+				PyObject *s_python_function_ion;
+				PyObject *s_python_function_ginput;
+				PyObject *s_python_function_ylim;
+				PyObject *s_python_function_title;
+				PyObject *s_python_function_axis;
+				PyObject *s_python_function_axvline;
+				PyObject *s_python_function_xlabel;
+				PyObject *s_python_function_ylabel;
+				PyObject *s_python_function_gca;
+				PyObject *s_python_function_xticks;
+				PyObject *s_python_function_yticks;
+				PyObject *s_python_function_tick_params;
+				PyObject *s_python_function_grid;
+				PyObject *s_python_function_clf;
+				PyObject *s_python_function_errorbar;
+				PyObject *s_python_function_annotate;
+				PyObject *s_python_function_tight_layout;
+				PyObject *s_python_colormap;
+				PyObject *s_python_empty_tuple;
+				PyObject *s_python_function_stem;
+				PyObject *s_python_function_xkcd;
+				PyObject *s_python_function_text;
+				PyObject *s_python_function_suptitle;
+				PyObject *s_python_function_bar;
+				PyObject *s_python_function_hbar;
+				PyObject *s_python_function_colorbar;
+				PyObject *s_python_function_subplots_adjust;
 
+				/* For now, _interpreter is implemented as a singleton since its currently not possible to have
+				 multiple independent embedded python interpreters without patching the python source code
+				 or starting a separate process for each.
+				 http://bytes.com/topic/python/answers/793370-multiple-independent-python-interpreters-c-c-program
+				 */
 
-    /* For now, _interpreter is implemented as a singleton since its currently not possible to have
-       multiple independent embedded python interpreters without patching the python source code
-       or starting a separate process for each.
-        http://bytes.com/topic/python/answers/793370-multiple-independent-python-interpreters-c-c-program
-       */
+				static _interpreter& get() {
+					static _interpreter ctx;
+					return ctx;
+				}
 
-    static _interpreter& get() {
-        static _interpreter ctx;
-        return ctx;
-    }
+				PyObject* safe_import(PyObject *module, std::string fname) {
+					PyObject *fn = PyObject_GetAttrString(module, fname.c_str());
 
-    PyObject* safe_import(PyObject* module, std::string fname) {
-        PyObject* fn = PyObject_GetAttrString(module, fname.c_str());
+					if (!fn) throw std::runtime_error(std::string("Couldn't find required function: ") + fname);
 
-        if (!fn)
-            throw std::runtime_error(std::string("Couldn't find required function: ") + fname);
+					if (!PyFunction_Check(fn)) throw std::runtime_error(fname + std::string(" is unexpectedly not a PyFunction."));
 
-        if (!PyFunction_Check(fn))
-            throw std::runtime_error(fname + std::string(" is unexpectedly not a PyFunction."));
+					return fn;
+				}
 
-        return fn;
-    }
-
-private:
+			private:
 
 #ifndef WITHOUT_NUMPY
 #  if PY_MAJOR_VERSION >= 3
@@ -130,118 +127,125 @@ private:
 
 #  else
 
-    void import_numpy() {
-        import_array(); // initialize C-API
-    }
+				void import_numpy() {
+					import_array(); // initialize C-API
+				}
 
 #  endif
 #endif
 
-    _interpreter() {
+				_interpreter() {
 
-        // optional but recommended
+					// optional but recommended
 #if PY_MAJOR_VERSION >= 3
         wchar_t name[] = L"plotting";
 #else
-        char name[] = "plotting";
+					char name[] = "plotting";
 #endif
-        Py_SetProgramName(name);
-        Py_Initialize();
+					Py_SetProgramName(name);
+					Py_Initialize();
 
 #ifndef WITHOUT_NUMPY
-        import_numpy(); // initialize numpy C-API
+					import_numpy(); // initialize numpy C-API
 #endif
 
-        PyObject* matplotlibname = PyString_FromString("matplotlib");
-        PyObject* pyplotname = PyString_FromString("matplotlib.pyplot");
-        PyObject* cmname  = PyString_FromString("matplotlib.cm");
-        PyObject* pylabname  = PyString_FromString("pylab");
-        if (!pyplotname || !pylabname || !matplotlibname || !cmname) {
-            throw std::runtime_error("couldnt create string");
-        }
+					PyObject *matplotlibname = PyString_FromString("matplotlib");
+					PyObject *pyplotname = PyString_FromString("matplotlib.pyplot");
+					PyObject *cmname = PyString_FromString("matplotlib.cm");
+					PyObject *pylabname = PyString_FromString("pylab");
+					if (!pyplotname || !pylabname || !matplotlibname || !cmname) {
+						throw std::runtime_error("couldnt create string");
+					}
 
-        PyObject* matplotlib = PyImport_Import(matplotlibname);
-        Py_DECREF(matplotlibname);
-        if (!matplotlib) {
-            PyErr_Print();
-            throw std::runtime_error("Error loading module matplotlib!");
-        }
+					PyObject *matplotlib = PyImport_Import(matplotlibname);
+					Py_DECREF(matplotlibname);
+					if (!matplotlib) {
+						PyErr_Print();
+						throw std::runtime_error("Error loading module matplotlib!");
+					}
 
-        // matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
-        // or matplotlib.backends is imported for the first time
-        if (!s_backend.empty()) {
-            PyObject_CallMethod(matplotlib, const_cast<char*>("use"), const_cast<char*>("s"), s_backend.c_str());
-        }
+					// matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
+					// or matplotlib.backends is imported for the first time
+					if (!s_backend.empty()) {
+						PyObject_CallMethod(matplotlib, const_cast<char*>("use"), const_cast<char*>("s"), s_backend.c_str());
+					}
 
-        PyObject* pymod = PyImport_Import(pyplotname);
-        Py_DECREF(pyplotname);
-        if (!pymod) { throw std::runtime_error("Error loading module matplotlib.pyplot!"); }
+					PyObject *pymod = PyImport_Import(pyplotname);
+					Py_DECREF(pyplotname);
+					if (!pymod) {
+						throw std::runtime_error("Error loading module matplotlib.pyplot!");
+					}
 
-        s_python_colormap = PyImport_Import(cmname);
-        Py_DECREF(cmname);
-        if (!s_python_colormap) { throw std::runtime_error("Error loading module matplotlib.cm!"); }
+					s_python_colormap = PyImport_Import(cmname);
+					Py_DECREF(cmname);
+					if (!s_python_colormap) {
+						throw std::runtime_error("Error loading module matplotlib.cm!");
+					}
 
-        PyObject* pylabmod = PyImport_Import(pylabname);
-        Py_DECREF(pylabname);
-        if (!pylabmod) { throw std::runtime_error("Error loading module pylab!"); }
+					PyObject *pylabmod = PyImport_Import(pylabname);
+					Py_DECREF(pylabname);
+					if (!pylabmod) {
+						throw std::runtime_error("Error loading module pylab!");
+					}
 
-        s_python_function_show = safe_import(pymod, "show");
-        s_python_function_close = safe_import(pymod, "close");
-        s_python_function_draw = safe_import(pymod, "draw");
-        s_python_function_pause = safe_import(pymod, "pause");
-        s_python_function_figure = safe_import(pymod, "figure");
-        s_python_function_fignum_exists = safe_import(pymod, "fignum_exists");
-        s_python_function_plot = safe_import(pymod, "plot");
-        s_python_function_quiver = safe_import(pymod, "quiver");
-        s_python_function_semilogx = safe_import(pymod, "semilogx");
-        s_python_function_semilogy = safe_import(pymod, "semilogy");
-        s_python_function_loglog = safe_import(pymod, "loglog");
-        s_python_function_fill = safe_import(pymod, "fill");
-        s_python_function_fill_between = safe_import(pymod, "fill_between");
-        s_python_function_hist = safe_import(pymod,"hist");
-        s_python_function_scatter = safe_import(pymod,"scatter");
-        s_python_function_boxplot = safe_import(pymod,"boxplot");
-        s_python_function_subplot = safe_import(pymod, "subplot");
-        s_python_function_subplot2grid = safe_import(pymod, "subplot2grid");
-        s_python_function_legend = safe_import(pymod, "legend");
-        s_python_function_ylim = safe_import(pymod, "ylim");
-        s_python_function_title = safe_import(pymod, "title");
-        s_python_function_axis = safe_import(pymod, "axis");
-        s_python_function_axvline = safe_import(pymod, "axvline");
-        s_python_function_xlabel = safe_import(pymod, "xlabel");
-        s_python_function_ylabel = safe_import(pymod, "ylabel");
-        s_python_function_gca = safe_import(pymod, "gca");
-        s_python_function_xticks = safe_import(pymod, "xticks");
-        s_python_function_yticks = safe_import(pymod, "yticks");
-        s_python_function_tick_params = safe_import(pymod, "tick_params");
-        s_python_function_grid = safe_import(pymod, "grid");
-        s_python_function_xlim = safe_import(pymod, "xlim");
-        s_python_function_ion = safe_import(pymod, "ion");
-        s_python_function_ginput = safe_import(pymod, "ginput");
-        s_python_function_save = safe_import(pylabmod, "savefig");
-        s_python_function_annotate = safe_import(pymod,"annotate");
-        s_python_function_clf = safe_import(pymod, "clf");
-        s_python_function_errorbar = safe_import(pymod, "errorbar");
-        s_python_function_tight_layout = safe_import(pymod, "tight_layout");
-        s_python_function_stem = safe_import(pymod, "stem");
-        s_python_function_xkcd = safe_import(pymod, "xkcd");
-        s_python_function_text = safe_import(pymod, "text");
-        s_python_function_suptitle = safe_import(pymod, "suptitle");
-        s_python_function_bar = safe_import(pymod,"bar");
-        s_python_function_colorbar = PyObject_GetAttrString(pymod, "colorbar");
-        s_python_function_subplots_adjust = safe_import(pymod,"subplots_adjust");
+					s_python_function_show = safe_import(pymod, "show");
+					s_python_function_close = safe_import(pymod, "close");
+					s_python_function_draw = safe_import(pymod, "draw");
+					s_python_function_pause = safe_import(pymod, "pause");
+					s_python_function_figure = safe_import(pymod, "figure");
+					s_python_function_fignum_exists = safe_import(pymod, "fignum_exists");
+					s_python_function_plot = safe_import(pymod, "plot");
+					s_python_function_quiver = safe_import(pymod, "quiver");
+					s_python_function_semilogx = safe_import(pymod, "semilogx");
+					s_python_function_semilogy = safe_import(pymod, "semilogy");
+					s_python_function_loglog = safe_import(pymod, "loglog");
+					s_python_function_fill = safe_import(pymod, "fill");
+					s_python_function_fill_between = safe_import(pymod, "fill_between");
+					s_python_function_hist = safe_import(pymod, "hist");
+					s_python_function_scatter = safe_import(pymod, "scatter");
+					s_python_function_boxplot = safe_import(pymod, "boxplot");
+					s_python_function_subplot = safe_import(pymod, "subplot");
+					s_python_function_subplot2grid = safe_import(pymod, "subplot2grid");
+					s_python_function_legend = safe_import(pymod, "legend");
+					s_python_function_ylim = safe_import(pymod, "ylim");
+					s_python_function_title = safe_import(pymod, "title");
+					s_python_function_axis = safe_import(pymod, "axis");
+					s_python_function_axvline = safe_import(pymod, "axvline");
+					s_python_function_xlabel = safe_import(pymod, "xlabel");
+					s_python_function_ylabel = safe_import(pymod, "ylabel");
+					s_python_function_gca = safe_import(pymod, "gca");
+					s_python_function_xticks = safe_import(pymod, "xticks");
+					s_python_function_yticks = safe_import(pymod, "yticks");
+					s_python_function_tick_params = safe_import(pymod, "tick_params");
+					s_python_function_grid = safe_import(pymod, "grid");
+					s_python_function_xlim = safe_import(pymod, "xlim");
+					s_python_function_ion = safe_import(pymod, "ion");
+					s_python_function_ginput = safe_import(pymod, "ginput");
+					s_python_function_save = safe_import(pylabmod, "savefig");
+					s_python_function_annotate = safe_import(pymod, "annotate");
+					s_python_function_clf = safe_import(pymod, "clf");
+					s_python_function_errorbar = safe_import(pymod, "errorbar");
+					s_python_function_tight_layout = safe_import(pymod, "tight_layout");
+					s_python_function_stem = safe_import(pymod, "stem");
+					s_python_function_xkcd = safe_import(pymod, "xkcd");
+					s_python_function_text = safe_import(pymod, "text");
+					s_python_function_suptitle = safe_import(pymod, "suptitle");
+					s_python_function_bar = safe_import(pymod, "bar");
+					s_python_function_hbar = safe_import(pymod, "barh");
+					s_python_function_colorbar = PyObject_GetAttrString(pymod, "colorbar");
+					s_python_function_subplots_adjust = safe_import(pymod, "subplots_adjust");
 #ifndef WITHOUT_NUMPY
-        s_python_function_imshow = safe_import(pymod, "imshow");
+					s_python_function_imshow = safe_import(pymod, "imshow");
 #endif
-        s_python_empty_tuple = PyTuple_New(0);
-    }
+					s_python_empty_tuple = PyTuple_New(0);
+				}
 
-    ~_interpreter() {
-        Py_Finalize();
-    }
-};
+				~_interpreter() {
+					Py_Finalize();
+				}
+		};
 
-} // end namespace detail
+	} // end namespace detail
 
 /// Select the backend
 ///
@@ -252,104 +256,125 @@ private:
 /// matplotlibcpp in headless mode, for example on a machine with no display.
 ///
 /// See also: https://matplotlib.org/2.0.2/api/matplotlib_configuration_api.html#matplotlib.use
-inline void backend(const std::string& name)
-{
-    detail::s_backend = name;
-}
+	inline void backend(const std::string &name) {
+		detail::s_backend = name;
+	}
 
-inline bool annotate(std::string annotation, double x, double y)
-{
-    detail::_interpreter::get();
+	inline bool annotate(std::string annotation, double x, double y) {
+		detail::_interpreter::get();
 
-    PyObject * xy = PyTuple_New(2);
-    PyObject * str = PyString_FromString(annotation.c_str());
+		PyObject *xy = PyTuple_New(2);
+		PyObject *str = PyString_FromString(annotation.c_str());
 
-    PyTuple_SetItem(xy,0,PyFloat_FromDouble(x));
-    PyTuple_SetItem(xy,1,PyFloat_FromDouble(y));
+		PyTuple_SetItem(xy, 0, PyFloat_FromDouble(x));
+		PyTuple_SetItem(xy, 1, PyFloat_FromDouble(y));
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "xy", xy);
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "xy", xy);
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, str);
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, str);
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_annotate, args, kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_annotate, args, kwargs);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
 
-    if(res) Py_DECREF(res);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
-namespace detail {
+	namespace detail {
 
 #ifndef WITHOUT_NUMPY
 // Type selector for numpy array conversion
-template <typename T> struct select_npy_type { const static NPY_TYPES type = NPY_NOTYPE; }; //Default
-template <> struct select_npy_type<double> { const static NPY_TYPES type = NPY_DOUBLE; };
-template <> struct select_npy_type<float> { const static NPY_TYPES type = NPY_FLOAT; };
-template <> struct select_npy_type<bool> { const static NPY_TYPES type = NPY_BOOL; };
-template <> struct select_npy_type<int8_t> { const static NPY_TYPES type = NPY_INT8; };
-template <> struct select_npy_type<int16_t> { const static NPY_TYPES type = NPY_SHORT; };
-template <> struct select_npy_type<int32_t> { const static NPY_TYPES type = NPY_INT; };
-template <> struct select_npy_type<int64_t> { const static NPY_TYPES type = NPY_INT64; };
-template <> struct select_npy_type<uint8_t> { const static NPY_TYPES type = NPY_UINT8; };
-template <> struct select_npy_type<uint16_t> { const static NPY_TYPES type = NPY_USHORT; };
-template <> struct select_npy_type<uint32_t> { const static NPY_TYPES type = NPY_ULONG; };
-template <> struct select_npy_type<uint64_t> { const static NPY_TYPES type = NPY_UINT64; };
+		template<typename T> struct select_npy_type {
+				const static NPY_TYPES type = NPY_NOTYPE;
+		};
+		//Default
+		template<> struct select_npy_type<double> {
+				const static NPY_TYPES type = NPY_DOUBLE;
+		};
+		template<> struct select_npy_type<float> {
+				const static NPY_TYPES type = NPY_FLOAT;
+		};
+		template<> struct select_npy_type<bool> {
+				const static NPY_TYPES type = NPY_BOOL;
+		};
+		template<> struct select_npy_type<int8_t> {
+				const static NPY_TYPES type = NPY_INT8;
+		};
+		template<> struct select_npy_type<int16_t> {
+				const static NPY_TYPES type = NPY_SHORT;
+		};
+		template<> struct select_npy_type<int32_t> {
+				const static NPY_TYPES type = NPY_INT;
+		};
+		template<> struct select_npy_type<int64_t> {
+				const static NPY_TYPES type = NPY_INT64;
+		};
+		template<> struct select_npy_type<uint8_t> {
+				const static NPY_TYPES type = NPY_UINT8;
+		};
+		template<> struct select_npy_type<uint16_t> {
+				const static NPY_TYPES type = NPY_USHORT;
+		};
+		template<> struct select_npy_type<uint32_t> {
+				const static NPY_TYPES type = NPY_ULONG;
+		};
+		template<> struct select_npy_type<uint64_t> {
+				const static NPY_TYPES type = NPY_UINT64;
+		};
 
 // Sanity checks; comment them out or change the numpy type below if you're compiling on
 // a platform where they don't apply
-static_assert(sizeof(long long) == 8);
-template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
-static_assert(sizeof(unsigned long long) == 8);
-template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
+		static_assert(sizeof(long long) == 8);
+		template<> struct select_npy_type<long long> {
+				const static NPY_TYPES type = NPY_INT64;
+		};
+		static_assert(sizeof(unsigned long long) == 8);
+		template<> struct select_npy_type<unsigned long long> {
+				const static NPY_TYPES type = NPY_UINT64;
+		};
 // TODO: add int, long, etc.
 
-template<typename Numeric>
-PyObject* get_array(const std::vector<Numeric>& v)
-{
-    npy_intp vsize = v.size();
-    NPY_TYPES type = select_npy_type<Numeric>::type;
-    if (type == NPY_NOTYPE) {
-        size_t memsize = v.size()*sizeof(double);
-        double* dp = static_cast<double*>(::malloc(memsize));
-        for (size_t i=0; i<v.size(); ++i)
-            dp[i] = v[i];
-        PyObject* varray = PyArray_SimpleNewFromData(1, &vsize, NPY_DOUBLE, dp);
-        PyArray_UpdateFlags(reinterpret_cast<PyArrayObject*>(varray), NPY_ARRAY_OWNDATA);
-        return varray;
-    }
-    
-    PyObject* varray = PyArray_SimpleNewFromData(1, &vsize, type, (void*)(v.data()));
-    return varray;
-}
+		template<typename Numeric>
+		PyObject* get_array(const std::vector<Numeric> &v) {
+			npy_intp vsize = v.size();
+			NPY_TYPES type = select_npy_type<Numeric>::type;
+			if (type == NPY_NOTYPE) {
+				size_t memsize = v.size() * sizeof(double);
+				double *dp = static_cast<double*>(::malloc(memsize));
+				for (size_t i = 0; i < v.size(); ++i)
+					dp[i] = v[i];
+				PyObject *varray = PyArray_SimpleNewFromData(1, &vsize, NPY_DOUBLE, dp);
+				PyArray_UpdateFlags(reinterpret_cast<PyArrayObject*>(varray), NPY_ARRAY_OWNDATA);
+				return varray;
+			}
 
+			PyObject *varray = PyArray_SimpleNewFromData(1, &vsize, type, (void* )(v.data()));
+			return varray;
+		}
 
-template<typename Numeric>
-PyObject* get_2darray(const std::vector<::std::vector<Numeric>>& v)
-{
-    if (v.size() < 1) throw std::runtime_error("get_2d_array v too small");
+		template<typename Numeric>
+		PyObject* get_2darray(const std::vector<::std::vector<Numeric>> &v) {
+			if (v.size() < 1) throw std::runtime_error("get_2d_array v too small");
 
-    npy_intp vsize[2] = {static_cast<npy_intp>(v.size()),
-                         static_cast<npy_intp>(v[0].size())};
+			npy_intp vsize[2] = { static_cast<npy_intp>(v.size()), static_cast<npy_intp>(v[0].size()) };
 
-    PyArrayObject *varray =
-        (PyArrayObject *)PyArray_SimpleNew(2, vsize, NPY_DOUBLE);
+			PyArrayObject *varray = (PyArrayObject*) PyArray_SimpleNew(2, vsize, NPY_DOUBLE);
 
-    double *vd_begin = static_cast<double *>(PyArray_DATA(varray));
+			double *vd_begin = static_cast<double*>(PyArray_DATA(varray));
 
-    for (const ::std::vector<Numeric> &v_row : v) {
-      if (v_row.size() != static_cast<size_t>(vsize[1]))
-        throw std::runtime_error("Missmatched array size");
-      std::copy(v_row.begin(), v_row.end(), vd_begin);
-      vd_begin += vsize[1];
-    }
+			for (const ::std::vector<Numeric> &v_row : v) {
+				if (v_row.size() != static_cast<size_t>(vsize[1])) throw std::runtime_error("Missmatched array size");
+				std::copy(v_row.begin(), v_row.end(), vd_begin);
+				vd_begin += vsize[1];
+			}
 
-    return reinterpret_cast<PyObject *>(varray);
-}
+			return reinterpret_cast<PyObject*>(varray);
+		}
 
 #else // fallback if we don't have numpy: copy every element of the given vector
 
@@ -366,420 +391,388 @@ PyObject* get_array(const std::vector<Numeric>& v)
 #endif // WITHOUT_NUMPY
 
 // sometimes, for labels and such, we need string arrays
-inline PyObject * get_array(const std::vector<std::string>& strings)
-{
-  PyObject* list = PyList_New(strings.size());
-  for (std::size_t i = 0; i < strings.size(); ++i) {
-    PyList_SetItem(list, i, PyString_FromString(strings[i].c_str()));
-  }
-  return list;
-}
+		inline PyObject* get_array(const std::vector<std::string> &strings) {
+			PyObject *list = PyList_New(strings.size());
+			for (std::size_t i = 0; i < strings.size(); ++i) {
+				PyList_SetItem(list, i, PyString_FromString(strings[i].c_str()));
+			}
+			return list;
+		}
 
 // not all matplotlib need 2d arrays, some prefer lists of lists
-template<typename Numeric>
-PyObject* get_listlist(const std::vector<std::vector<Numeric>>& ll)
-{
-  PyObject* listlist = PyList_New(ll.size());
-  for (std::size_t i = 0; i < ll.size(); ++i) {
-    PyList_SetItem(listlist, i, get_array(ll[i]));
-  }
-  return listlist;
-}
+		template<typename Numeric>
+		PyObject* get_listlist(const std::vector<std::vector<Numeric>> &ll) {
+			PyObject *listlist = PyList_New(ll.size());
+			for (std::size_t i = 0; i < ll.size(); ++i) {
+				PyList_SetItem(listlist, i, get_array(ll[i]));
+			}
+			return listlist;
+		}
 
-} // namespace detail
+	} // namespace detail
 
 /// Plot a line through the given x and y data points..
 /// 
 /// See: https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.plot.html
-template<typename Numeric>
-bool plot(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::map<std::string, std::string>& keywords)
-{
-    assert(x.size() == y.size());
+	template<typename Numeric>
+	bool plot(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::map<std::string, std::string> &keywords) {
+		assert(x.size() == y.size());
 
-    detail::_interpreter::get();
+		detail::_interpreter::get();
 
-    // using numpy arrays
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		// using numpy arrays
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    // construct positional args
-    PyObject* args = PyTuple_New(2);
-    PyTuple_SetItem(args, 0, xarray);
-    PyTuple_SetItem(args, 1, yarray);
+		// construct positional args
+		PyObject *args = PyTuple_New(2);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, yarray);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-    }
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, args, kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, args, kwargs);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
 // TODO - it should be possible to make this work by implementing
 // a non-numpy alternative for `detail::get_2darray()`.
 #ifndef WITHOUT_NUMPY
-template <typename Numeric>
-void plot_surface(const std::vector<::std::vector<Numeric>> &x,
-                  const std::vector<::std::vector<Numeric>> &y,
-                  const std::vector<::std::vector<Numeric>> &z,
-                  const std::map<std::string, std::string> &keywords =
-                      std::map<std::string, std::string>())
-{
-  detail::_interpreter::get();
+	template<typename Numeric>
+	void plot_surface(const std::vector<::std::vector<Numeric>> &x, const std::vector<::std::vector<Numeric>> &y, const std::vector<::std::vector<Numeric>> &z, const std::map<std::string, std::string> &keywords = std::map<std::string, std::string>()) {
+		detail::_interpreter::get();
 
-  // We lazily load the modules here the first time this function is called
-  // because I'm not sure that we can assume "matplotlib installed" implies
-  // "mpl_toolkits installed" on all platforms, and we don't want to require
-  // it for people who don't need 3d plots.
-  static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
-  if (!mpl_toolkitsmod) {
-    detail::_interpreter::get();
+		// We lazily load the modules here the first time this function is called
+		// because I'm not sure that we can assume "matplotlib installed" implies
+		// "mpl_toolkits installed" on all platforms, and we don't want to require
+		// it for people who don't need 3d plots.
+		static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
+		if (!mpl_toolkitsmod) {
+			detail::_interpreter::get();
 
-    PyObject* mpl_toolkits = PyString_FromString("mpl_toolkits");
-    PyObject* axis3d = PyString_FromString("mpl_toolkits.mplot3d");
-    if (!mpl_toolkits || !axis3d) { throw std::runtime_error("couldnt create string"); }
+			PyObject *mpl_toolkits = PyString_FromString("mpl_toolkits");
+			PyObject *axis3d = PyString_FromString("mpl_toolkits.mplot3d");
+			if (!mpl_toolkits || !axis3d) {
+				throw std::runtime_error("couldnt create string");
+			}
 
-    mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
-    Py_DECREF(mpl_toolkits);
-    if (!mpl_toolkitsmod) { throw std::runtime_error("Error loading module mpl_toolkits!"); }
+			mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
+			Py_DECREF(mpl_toolkits);
+			if (!mpl_toolkitsmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits!");
+			}
 
-    axis3dmod = PyImport_Import(axis3d);
-    Py_DECREF(axis3d);
-    if (!axis3dmod) { throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!"); }
-  }
+			axis3dmod = PyImport_Import(axis3d);
+			Py_DECREF(axis3d);
+			if (!axis3dmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!");
+			}
+		}
 
-  assert(x.size() == y.size());
-  assert(y.size() == z.size());
+		assert(x.size() == y.size());
+		assert(y.size() == z.size());
 
-  // using numpy arrays
-  PyObject *xarray = detail::get_2darray(x);
-  PyObject *yarray = detail::get_2darray(y);
-  PyObject *zarray = detail::get_2darray(z);
+		// using numpy arrays
+		PyObject *xarray = detail::get_2darray(x);
+		PyObject *yarray = detail::get_2darray(y);
+		PyObject *zarray = detail::get_2darray(z);
 
-  // construct positional args
-  PyObject *args = PyTuple_New(3);
-  PyTuple_SetItem(args, 0, xarray);
-  PyTuple_SetItem(args, 1, yarray);
-  PyTuple_SetItem(args, 2, zarray);
+		// construct positional args
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, yarray);
+		PyTuple_SetItem(args, 2, zarray);
 
-  // Build up the kw args.
-  PyObject *kwargs = PyDict_New();
-  PyDict_SetItemString(kwargs, "rstride", PyInt_FromLong(1));
-  PyDict_SetItemString(kwargs, "cstride", PyInt_FromLong(1));
+		// Build up the kw args.
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "rstride", PyInt_FromLong(1));
+		PyDict_SetItemString(kwargs, "cstride", PyInt_FromLong(1));
 
-  PyObject *python_colormap_coolwarm = PyObject_GetAttrString(
-      detail::_interpreter::get().s_python_colormap, "coolwarm");
+		PyObject *python_colormap_coolwarm = PyObject_GetAttrString(detail::_interpreter::get().s_python_colormap, "coolwarm");
 
-  PyDict_SetItemString(kwargs, "cmap", python_colormap_coolwarm);
+		PyDict_SetItemString(kwargs, "cmap", python_colormap_coolwarm);
 
-  for (std::map<std::string, std::string>::const_iterator it = keywords.begin();
-       it != keywords.end(); ++it) {
-    PyDict_SetItemString(kwargs, it->first.c_str(),
-                         PyString_FromString(it->second.c_str()));
-  }
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
+		PyObject *fig = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
+		if (!fig) throw std::runtime_error("Call to figure() failed.");
 
-  PyObject *fig =
-      PyObject_CallObject(detail::_interpreter::get().s_python_function_figure,
-                          detail::_interpreter::get().s_python_empty_tuple);
-  if (!fig) throw std::runtime_error("Call to figure() failed.");
+		PyObject *gca_kwargs = PyDict_New();
+		PyDict_SetItemString(gca_kwargs, "projection", PyString_FromString("3d"));
 
-  PyObject *gca_kwargs = PyDict_New();
-  PyDict_SetItemString(gca_kwargs, "projection", PyString_FromString("3d"));
+		PyObject *gca = PyObject_GetAttrString(fig, "gca");
+		if (!gca) throw std::runtime_error("No gca");
+		Py_INCREF(gca);
+		PyObject *axis = PyObject_Call(gca, detail::_interpreter::get().s_python_empty_tuple, gca_kwargs);
 
-  PyObject *gca = PyObject_GetAttrString(fig, "gca");
-  if (!gca) throw std::runtime_error("No gca");
-  Py_INCREF(gca);
-  PyObject *axis = PyObject_Call(
-      gca, detail::_interpreter::get().s_python_empty_tuple, gca_kwargs);
+		if (!axis) throw std::runtime_error("No axis");
+		Py_INCREF(axis);
 
-  if (!axis) throw std::runtime_error("No axis");
-  Py_INCREF(axis);
+		Py_DECREF(gca);
+		Py_DECREF(gca_kwargs);
 
-  Py_DECREF(gca);
-  Py_DECREF(gca_kwargs);
+		PyObject *plot_surface = PyObject_GetAttrString(axis, "plot_surface");
+		if (!plot_surface) throw std::runtime_error("No surface");
+		Py_INCREF(plot_surface);
+		PyObject *res = PyObject_Call(plot_surface, args, kwargs);
+		if (!res) throw std::runtime_error("failed surface");
+		Py_DECREF(plot_surface);
 
-  PyObject *plot_surface = PyObject_GetAttrString(axis, "plot_surface");
-  if (!plot_surface) throw std::runtime_error("No surface");
-  Py_INCREF(plot_surface);
-  PyObject *res = PyObject_Call(plot_surface, args, kwargs);
-  if (!res) throw std::runtime_error("failed surface");
-  Py_DECREF(plot_surface);
-
-  Py_DECREF(axis);
-  Py_DECREF(args);
-  Py_DECREF(kwargs);
-  if (res) Py_DECREF(res);
-}
+		Py_DECREF(axis);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
+	}
 #endif // WITHOUT_NUMPY
 
-template <typename Numeric>
-void plot3(const std::vector<Numeric> &x,
-                  const std::vector<Numeric> &y,
-                  const std::vector<Numeric> &z,
-                  const std::map<std::string, std::string> &keywords =
-                      std::map<std::string, std::string>())
-{
-  detail::_interpreter::get();
+	template<typename Numeric>
+	void plot3(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::vector<Numeric> &z, const std::map<std::string, std::string> &keywords = std::map<std::string, std::string>()) {
+		detail::_interpreter::get();
 
-  // Same as with plot_surface: We lazily load the modules here the first time 
-  // this function is called because I'm not sure that we can assume "matplotlib 
-  // installed" implies "mpl_toolkits installed" on all platforms, and we don't 
-  // want to require it for people who don't need 3d plots.
-  static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
-  if (!mpl_toolkitsmod) {
-    detail::_interpreter::get();
+		// Same as with plot_surface: We lazily load the modules here the first time 
+		// this function is called because I'm not sure that we can assume "matplotlib 
+		// installed" implies "mpl_toolkits installed" on all platforms, and we don't 
+		// want to require it for people who don't need 3d plots.
+		static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
+		if (!mpl_toolkitsmod) {
+			detail::_interpreter::get();
 
-    PyObject* mpl_toolkits = PyString_FromString("mpl_toolkits");
-    PyObject* axis3d = PyString_FromString("mpl_toolkits.mplot3d");
-    if (!mpl_toolkits || !axis3d) { throw std::runtime_error("couldnt create string"); }
+			PyObject *mpl_toolkits = PyString_FromString("mpl_toolkits");
+			PyObject *axis3d = PyString_FromString("mpl_toolkits.mplot3d");
+			if (!mpl_toolkits || !axis3d) {
+				throw std::runtime_error("couldnt create string");
+			}
 
-    mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
-    Py_DECREF(mpl_toolkits);
-    if (!mpl_toolkitsmod) { throw std::runtime_error("Error loading module mpl_toolkits!"); }
+			mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
+			Py_DECREF(mpl_toolkits);
+			if (!mpl_toolkitsmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits!");
+			}
 
-    axis3dmod = PyImport_Import(axis3d);
-    Py_DECREF(axis3d);
-    if (!axis3dmod) { throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!"); }
-  }
+			axis3dmod = PyImport_Import(axis3d);
+			Py_DECREF(axis3d);
+			if (!axis3dmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!");
+			}
+		}
 
-  assert(x.size() == y.size());
-  assert(y.size() == z.size());
+		assert(x.size() == y.size());
+		assert(y.size() == z.size());
 
-  PyObject *xarray = detail::get_array(x);
-  PyObject *yarray = detail::get_array(y);
-  PyObject *zarray = detail::get_array(z);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
+		PyObject *zarray = detail::get_array(z);
 
-  // construct positional args
-  PyObject *args = PyTuple_New(3);
-  PyTuple_SetItem(args, 0, xarray);
-  PyTuple_SetItem(args, 1, yarray);
-  PyTuple_SetItem(args, 2, zarray);
+		// construct positional args
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, yarray);
+		PyTuple_SetItem(args, 2, zarray);
 
-  // Build up the kw args.
-  PyObject *kwargs = PyDict_New();
+		// Build up the kw args.
+		PyObject *kwargs = PyDict_New();
 
-  for (std::map<std::string, std::string>::const_iterator it = keywords.begin();
-       it != keywords.end(); ++it) {
-    PyDict_SetItemString(kwargs, it->first.c_str(),
-                         PyString_FromString(it->second.c_str()));
-  }
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-  PyObject *fig =
-      PyObject_CallObject(detail::_interpreter::get().s_python_function_figure,
-                          detail::_interpreter::get().s_python_empty_tuple);
-  if (!fig) throw std::runtime_error("Call to figure() failed.");
+		PyObject *fig = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
+		if (!fig) throw std::runtime_error("Call to figure() failed.");
 
-  PyObject *gca_kwargs = PyDict_New();
-  PyDict_SetItemString(gca_kwargs, "projection", PyString_FromString("3d"));
+		PyObject *gca_kwargs = PyDict_New();
+		PyDict_SetItemString(gca_kwargs, "projection", PyString_FromString("3d"));
 
-  PyObject *gca = PyObject_GetAttrString(fig, "gca");
-  if (!gca) throw std::runtime_error("No gca");
-  Py_INCREF(gca);
-  PyObject *axis = PyObject_Call(
-      gca, detail::_interpreter::get().s_python_empty_tuple, gca_kwargs);
+		PyObject *gca = PyObject_GetAttrString(fig, "gca");
+		if (!gca) throw std::runtime_error("No gca");
+		Py_INCREF(gca);
+		PyObject *axis = PyObject_Call(gca, detail::_interpreter::get().s_python_empty_tuple, gca_kwargs);
 
-  if (!axis) throw std::runtime_error("No axis");
-  Py_INCREF(axis);
+		if (!axis) throw std::runtime_error("No axis");
+		Py_INCREF(axis);
 
-  Py_DECREF(gca);
-  Py_DECREF(gca_kwargs);
+		Py_DECREF(gca);
+		Py_DECREF(gca_kwargs);
 
-  PyObject *plot3 = PyObject_GetAttrString(axis, "plot");
-  if (!plot3) throw std::runtime_error("No 3D line plot");
-  Py_INCREF(plot3);
-  PyObject *res = PyObject_Call(plot3, args, kwargs);
-  if (!res) throw std::runtime_error("Failed 3D line plot");
-  Py_DECREF(plot3);
+		PyObject *plot3 = PyObject_GetAttrString(axis, "plot");
+		if (!plot3) throw std::runtime_error("No 3D line plot");
+		Py_INCREF(plot3);
+		PyObject *res = PyObject_Call(plot3, args, kwargs);
+		if (!res) throw std::runtime_error("Failed 3D line plot");
+		Py_DECREF(plot3);
 
-  Py_DECREF(axis);
-  Py_DECREF(args);
-  Py_DECREF(kwargs);
-  if (res) Py_DECREF(res);
-}
+		Py_DECREF(axis);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
+	}
 
-template<typename Numeric>
-bool stem(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::map<std::string, std::string>& keywords)
-{
-    assert(x.size() == y.size());
+	template<typename Numeric>
+	bool stem(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::map<std::string, std::string> &keywords) {
+		assert(x.size() == y.size());
 
-    detail::_interpreter::get();
+		detail::_interpreter::get();
 
-    // using numpy arrays
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		// using numpy arrays
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    // construct positional args
-    PyObject* args = PyTuple_New(2);
-    PyTuple_SetItem(args, 0, xarray);
-    PyTuple_SetItem(args, 1, yarray);
+		// construct positional args
+		PyObject *args = PyTuple_New(2);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, yarray);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for (std::map<std::string, std::string>::const_iterator it =
-            keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(),
-                PyString_FromString(it->second.c_str()));
-    }
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(
-            detail::_interpreter::get().s_python_function_stem, args, kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_stem, args, kwargs);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if (res)
-        Py_DECREF(res);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
-template< typename Numeric >
-bool fill(const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::map<std::string, std::string>& keywords)
-{
-    assert(x.size() == y.size());
+	template<typename Numeric>
+	bool fill(const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::map<std::string, std::string> &keywords) {
+		assert(x.size() == y.size());
 
-    detail::_interpreter::get();
+		detail::_interpreter::get();
 
-    // using numpy arrays
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		// using numpy arrays
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    // construct positional args
-    PyObject* args = PyTuple_New(2);
-    PyTuple_SetItem(args, 0, xarray);
-    PyTuple_SetItem(args, 1, yarray);
+		// construct positional args
+		PyObject *args = PyTuple_New(2);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, yarray);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_fill, args, kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_fill, args, kwargs);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
 
-    if (res) Py_DECREF(res);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
-template< typename Numeric >
-bool fill_between(const std::vector<Numeric>& x, const std::vector<Numeric>& y1, const std::vector<Numeric>& y2, const std::map<std::string, std::string>& keywords)
-{
-    assert(x.size() == y1.size());
-    assert(x.size() == y2.size());
+	template<typename Numeric>
+	bool fill_between(const std::vector<Numeric> &x, const std::vector<Numeric> &y1, const std::vector<Numeric> &y2, const std::map<std::string, std::string> &keywords) {
+		assert(x.size() == y1.size());
+		assert(x.size() == y2.size());
 
-    detail::_interpreter::get();
+		detail::_interpreter::get();
 
-    // using numpy arrays
-    PyObject* xarray = detail::get_array(x);
-    PyObject* y1array = detail::get_array(y1);
-    PyObject* y2array = detail::get_array(y2);
+		// using numpy arrays
+		PyObject *xarray = detail::get_array(x);
+		PyObject *y1array = detail::get_array(y1);
+		PyObject *y2array = detail::get_array(y2);
 
-    // construct positional args
-    PyObject* args = PyTuple_New(3);
-    PyTuple_SetItem(args, 0, xarray);
-    PyTuple_SetItem(args, 1, y1array);
-    PyTuple_SetItem(args, 2, y2array);
+		// construct positional args
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, xarray);
+		PyTuple_SetItem(args, 1, y1array);
+		PyTuple_SetItem(args, 2, y2array);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_fill_between, args, kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_fill_between, args, kwargs);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
-template< typename Numeric>
-bool hist(const std::vector<Numeric>& y, long bins=10,std::string color="b",
-          double alpha=1.0, bool cumulative=false)
-{
-    detail::_interpreter::get();
+	template<typename Numeric>
+	bool hist(const std::vector<Numeric> &y, long bins = 10, std::string color = "b", double alpha = 1.0, bool cumulative = false) {
+		detail::_interpreter::get();
 
-    PyObject* yarray = detail::get_array(y);
+		PyObject *yarray = detail::get_array(y);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "bins", PyLong_FromLong(bins));
-    PyDict_SetItemString(kwargs, "color", PyString_FromString(color.c_str()));
-    PyDict_SetItemString(kwargs, "alpha", PyFloat_FromDouble(alpha));
-    PyDict_SetItemString(kwargs, "cumulative", cumulative ? Py_True : Py_False);
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "bins", PyLong_FromLong(bins));
+		PyDict_SetItemString(kwargs, "color", PyString_FromString(color.c_str()));
+		PyDict_SetItemString(kwargs, "alpha", PyFloat_FromDouble(alpha));
+		PyDict_SetItemString(kwargs, "cumulative", cumulative ? Py_True : Py_False);
 
-    PyObject* plot_args = PyTuple_New(1);
+		PyObject *plot_args = PyTuple_New(1);
 
-    PyTuple_SetItem(plot_args, 0, yarray);
+		PyTuple_SetItem(plot_args, 0, yarray);
 
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_hist, plot_args, kwargs);
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_hist, plot_args, kwargs);
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-
-    Py_DECREF(plot_args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
-
-    return res;
-}
+		return res;
+	}
 
 #ifndef WITHOUT_NUMPY
-namespace detail {
+	namespace detail {
 
-inline void imshow(void *ptr, const NPY_TYPES type, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords, PyObject** out)
-{
-    assert(type == NPY_UINT8 || type == NPY_FLOAT);
-    assert(colors == 1 || colors == 3 || colors == 4);
+		inline void imshow(void *ptr, const NPY_TYPES type, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords, PyObject **out) {
+			assert(type == NPY_UINT8 || type == NPY_FLOAT);
+			assert(colors == 1 || colors == 3 || colors == 4);
 
-    detail::_interpreter::get();
+			detail::_interpreter::get();
 
-    // construct args
-    npy_intp dims[3] = { rows, columns, colors };
-    PyObject *args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, PyArray_SimpleNewFromData(colors == 1 ? 2 : 3, dims, type, ptr));
+			// construct args
+			npy_intp dims[3] = { rows, columns, colors };
+			PyObject *args = PyTuple_New(1);
+			PyTuple_SetItem(args, 0, PyArray_SimpleNewFromData(colors == 1 ? 2 : 3, dims, type, ptr));
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+			// construct keyword args
+			PyObject *kwargs = PyDict_New();
+			for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+				PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+			}
 
-    PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_imshow, args, kwargs);
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if (!res)
-        throw std::runtime_error("Call to imshow() failed");
-    if (out)
-        *out = res;
-    else
-        Py_DECREF(res);
-}
+			PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_imshow, args, kwargs);
+			Py_DECREF(args);
+			Py_DECREF(kwargs);
+			if (!res) throw std::runtime_error("Call to imshow() failed");
+			if (out) *out = res;
+			else Py_DECREF(res);
+		}
 
-} // namespace detail
+	} // namespace detail
 
-inline void imshow(const unsigned char *ptr, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords = {}, PyObject** out = nullptr)
-{
-    detail::imshow((void *) ptr, NPY_UINT8, rows, columns, colors, keywords, out);
-}
+	inline void imshow(const unsigned char *ptr, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords = { }, PyObject **out = nullptr) {
+		detail::imshow((void*) ptr, NPY_UINT8, rows, columns, colors, keywords, out);
+	}
 
-inline void imshow(const float *ptr, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords = {}, PyObject** out = nullptr)
-{
-    detail::imshow((void *) ptr, NPY_FLOAT, rows, columns, colors, keywords, out);
-}
+	inline void imshow(const float *ptr, const int rows, const int columns, const int colors, const std::map<std::string, std::string> &keywords = { }, PyObject **out = nullptr) {
+		detail::imshow((void*) ptr, NPY_FLOAT, rows, columns, colors, keywords, out);
+	}
 
 #ifdef WITH_OPENCV
 void imshow(const cv::Mat &image, const std::map<std::string, std::string> &keywords = {})
@@ -813,1524 +806,1434 @@ void imshow(const cv::Mat &image, const std::map<std::string, std::string> &keyw
 #endif // WITH_OPENCV
 #endif // WITHOUT_NUMPY
 
-template<typename NumericX, typename NumericY>
-bool scatter(const std::vector<NumericX>& x,
-             const std::vector<NumericY>& y,
-             const double s=1.0, // The marker size in points**2
-             const std::map<std::string, std::string> & keywords = {})
-{
-    detail::_interpreter::get();
-
-    assert(x.size() == y.size());
-
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+	template<typename NumericX, typename NumericY>
+	bool scatter(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const double s = 1.0, // The marker size in points**2
+	        const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "s", PyLong_FromLong(s));
-    for (const auto& it : keywords)
-    {
-        PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
-    }
-
-    PyObject* plot_args = PyTuple_New(2);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_scatter, plot_args, kwargs);
-
-    Py_DECREF(plot_args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
-
-    return res;
-}
-
-template<typename Numeric>
-bool boxplot(const std::vector<std::vector<Numeric>>& data,
-             const std::vector<std::string>& labels = {},
-             const std::map<std::string, std::string> & keywords = {})
-{
-    detail::_interpreter::get();
-
-    PyObject* listlist = detail::get_listlist(data);
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, listlist);
-
-    PyObject* kwargs = PyDict_New();
-
-    // kwargs needs the labels, if there are (the correct number of) labels
-    if (!labels.empty() && labels.size() == data.size()) {
-        PyDict_SetItemString(kwargs, "labels", detail::get_array(labels));
-    }
-
-    // take care of the remaining keywords
-    for (const auto& it : keywords)
-    {
-        PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
-    }
-
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_boxplot, args, kwargs);
-
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-
-    if(res) Py_DECREF(res);
-
-    return res;
-}
-
-template<typename Numeric>
-bool boxplot(const std::vector<Numeric>& data,
-             const std::map<std::string, std::string> & keywords = {})
-{
-    detail::_interpreter::get();
+		assert(x.size() == y.size());
 
-    PyObject* vector = detail::get_array(data);
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, vector);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    PyObject* kwargs = PyDict_New();
-    for (const auto& it : keywords)
-    {
-        PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
-    }
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "s", PyLong_FromLong(s));
+		for (const auto &it : keywords) {
+			PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_boxplot, args, kwargs);
+		PyObject *plot_args = PyTuple_New(2);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_scatter, plot_args, kwargs);
 
-    if(res) Py_DECREF(res);
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    return res;
-}
+		return res;
+	}
 
-template <typename Numeric>
-bool bar(const std::vector<Numeric> &               x,
-         const std::vector<Numeric> &               y,
-         std::string                                ec       = "black",
-         std::string                                ls       = "-",
-         double                                     lw       = 1.0,
-         const std::map<std::string, std::string> & keywords = {})
-{
-  detail::_interpreter::get();
+	template<typename Numeric>
+	bool boxplot(const std::vector<std::vector<Numeric>> &data, const std::vector<std::string> &labels = { }, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-  PyObject * xarray = detail::get_array(x);
-  PyObject * yarray = detail::get_array(y);
+		PyObject *listlist = detail::get_listlist(data);
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, listlist);
 
-  PyObject * kwargs = PyDict_New();
+		PyObject *kwargs = PyDict_New();
 
-  PyDict_SetItemString(kwargs, "ec", PyString_FromString(ec.c_str()));
-  PyDict_SetItemString(kwargs, "ls", PyString_FromString(ls.c_str()));
-  PyDict_SetItemString(kwargs, "lw", PyFloat_FromDouble(lw));
+		// kwargs needs the labels, if there are (the correct number of) labels
+		if (!labels.empty() && labels.size() == data.size()) {
+			PyDict_SetItemString(kwargs, "labels", detail::get_array(labels));
+		}
 
-  for (std::map<std::string, std::string>::const_iterator it =
-         keywords.begin();
-       it != keywords.end();
-       ++it) {
-    PyDict_SetItemString(
-      kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-  }
+		// take care of the remaining keywords
+		for (const auto &it : keywords) {
+			PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
+		}
 
-  PyObject * plot_args = PyTuple_New(2);
-  PyTuple_SetItem(plot_args, 0, xarray);
-  PyTuple_SetItem(plot_args, 1, yarray);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_boxplot, args, kwargs);
 
-  PyObject * res = PyObject_Call(
-    detail::_interpreter::get().s_python_function_bar, plot_args, kwargs);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
 
-  Py_DECREF(plot_args);
-  Py_DECREF(kwargs);
-  if (res) Py_DECREF(res);
+		if (res) Py_DECREF(res);
 
-  return res;
-}
+		return res;
+	}
 
-template <typename Numeric>
-bool bar(const std::vector<Numeric> &               y,
-         std::string                                ec       = "black",
-         std::string                                ls       = "-",
-         double                                     lw       = 1.0,
-         const std::map<std::string, std::string> & keywords = {})
-{
-  using T = typename std::remove_reference<decltype(y)>::type::value_type;
+	template<typename Numeric>
+	bool boxplot(const std::vector<Numeric> &data, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-  detail::_interpreter::get();
+		PyObject *vector = detail::get_array(data);
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, vector);
 
-  std::vector<T> x;
-  for (std::size_t i = 0; i < y.size(); i++) { x.push_back(i); }
+		PyObject *kwargs = PyDict_New();
+		for (const auto &it : keywords) {
+			PyDict_SetItemString(kwargs, it.first.c_str(), PyString_FromString(it.second.c_str()));
+		}
 
-  return bar(x, y, ec, ls, lw, keywords);
-}
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_boxplot, args, kwargs);
 
-inline bool subplots_adjust(const std::map<std::string, double>& keywords = {})
-{
-    detail::_interpreter::get();
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
 
-    PyObject* kwargs = PyDict_New();
-    for (std::map<std::string, double>::const_iterator it =
-            keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(),
-                             PyFloat_FromDouble(it->second));
-    }
+		if (res) Py_DECREF(res);
 
+		return res;
+	}
 
-    PyObject* plot_args = PyTuple_New(0);
+	template<typename Numeric>
+	bool bar(const std::vector<Numeric> &x, const std::vector<Numeric> &y, std::string ec = "black", std::string ls = "-", double lw = 1.0, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_subplots_adjust, plot_args, kwargs);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    Py_DECREF(plot_args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
+		PyObject *kwargs = PyDict_New();
 
-    return res;
-}
+		PyDict_SetItemString(kwargs, "ec", PyString_FromString(ec.c_str()));
+		PyDict_SetItemString(kwargs, "ls", PyString_FromString(ls.c_str()));
+		PyDict_SetItemString(kwargs, "lw", PyFloat_FromDouble(lw));
 
-template< typename Numeric>
-bool named_hist(std::string label,const std::vector<Numeric>& y, long bins=10, std::string color="b", double alpha=1.0)
-{
-    detail::_interpreter::get();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* yarray = detail::get_array(y);
+		PyObject *plot_args = PyTuple_New(2);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(label.c_str()));
-    PyDict_SetItemString(kwargs, "bins", PyLong_FromLong(bins));
-    PyDict_SetItemString(kwargs, "color", PyString_FromString(color.c_str()));
-    PyDict_SetItemString(kwargs, "alpha", PyFloat_FromDouble(alpha));
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_bar, plot_args, kwargs);
 
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    PyObject* plot_args = PyTuple_New(1);
-    PyTuple_SetItem(plot_args, 0, yarray);
+		return res;
+	}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_hist, plot_args, kwargs);
+	template<typename Numeric>
+	bool hbar(const std::vector<Numeric> &x, const std::vector<Numeric> &y, std::string ec = "black", std::string ls = "-", double lw = 1.0, const std::map<std::string, std::string> &keywords = { }) {
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    Py_DECREF(plot_args);
-    Py_DECREF(kwargs);
-    if(res) Py_DECREF(res);
+		PyObject *kwargs = PyDict_New();
 
-    return res;
-}
+		PyDict_SetItemString(kwargs, "ec", PyString_FromString(ec.c_str()));
+		PyDict_SetItemString(kwargs, "ls", PyString_FromString(ls.c_str()));
+		PyDict_SetItemString(kwargs, "lw", PyFloat_FromDouble(lw));
 
-template<typename NumericX, typename NumericY>
-bool plot(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::string& s = "")
-{
-    assert(x.size() == y.size());
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    detail::_interpreter::get();
+		PyObject *plot_args = PyTuple_New(2);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_hbar, plot_args, kwargs);
 
-    PyObject* pystring = PyString_FromString(s.c_str());
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		return res;
+	}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_plot, plot_args);
+	template<typename Numeric>
+	bool bar(const std::vector<Numeric> &y, std::string ec = "black", std::string ls = "-", double lw = 1.0, const std::map<std::string, std::string> &keywords = { }) {
+		using T = typename std::remove_reference<decltype(y)>::type::value_type;
 
-    Py_DECREF(plot_args);
-    if(res) Py_DECREF(res);
+		detail::_interpreter::get();
 
-    return res;
-}
+		std::vector<T> x;
+		for (std::size_t i = 0; i < y.size(); i++) {
+			x.push_back(i);
+		}
 
-template<typename NumericX, typename NumericY, typename NumericU, typename NumericW>
-bool quiver(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::vector<NumericU>& u, const std::vector<NumericW>& w, const std::map<std::string, std::string>& keywords = {})
-{
-    assert(x.size() == y.size() && x.size() == u.size() && u.size() == w.size());
+		return bar(x, y, ec, ls, lw, keywords);
+	}
 
-    detail::_interpreter::get();
+	inline bool subplots_adjust(const std::map<std::string, double> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
-    PyObject* uarray = detail::get_array(u);
-    PyObject* warray = detail::get_array(w);
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, double>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyFloat_FromDouble(it->second));
+		}
 
-    PyObject* plot_args = PyTuple_New(4);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, uarray);
-    PyTuple_SetItem(plot_args, 3, warray);
+		PyObject *plot_args = PyTuple_New(0);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_subplots_adjust, plot_args, kwargs);
 
-    PyObject* res = PyObject_Call(
-            detail::_interpreter::get().s_python_function_quiver, plot_args, kwargs);
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res)
-        Py_DECREF(res);
+		return res;
+	}
 
-    return res;
-}
+	template<typename Numeric>
+	bool named_hist(std::string label, const std::vector<Numeric> &y, long bins = 10, std::string color = "b", double alpha = 1.0) {
+		detail::_interpreter::get();
 
-template<typename NumericX, typename NumericY>
-bool stem(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::string& s = "")
-{
-    assert(x.size() == y.size());
+		PyObject *yarray = detail::get_array(y);
 
-    detail::_interpreter::get();
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(label.c_str()));
+		PyDict_SetItemString(kwargs, "bins", PyLong_FromLong(bins));
+		PyDict_SetItemString(kwargs, "color", PyString_FromString(color.c_str()));
+		PyDict_SetItemString(kwargs, "alpha", PyFloat_FromDouble(alpha));
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyObject *plot_args = PyTuple_New(1);
+		PyTuple_SetItem(plot_args, 0, yarray);
 
-    PyObject* pystring = PyString_FromString(s.c_str());
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_hist, plot_args, kwargs);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		Py_DECREF(plot_args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
 
-    PyObject* res = PyObject_CallObject(
-            detail::_interpreter::get().s_python_function_stem, plot_args);
+		return res;
+	}
 
-    Py_DECREF(plot_args);
-    if (res)
-        Py_DECREF(res);
+	template<typename NumericX, typename NumericY>
+	bool plot(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::string &s = "") {
+		assert(x.size() == y.size());
 
-    return res;
-}
+		detail::_interpreter::get();
 
-template<typename NumericX, typename NumericY>
-bool semilogx(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::string& s = "")
-{
-    assert(x.size() == y.size());
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    detail::_interpreter::get();
+		PyObject *pystring = PyString_FromString(s.c_str());
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    PyObject* pystring = PyString_FromString(s.c_str());
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_plot, plot_args);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_semilogx, plot_args);
+		return res;
+	}
 
-    Py_DECREF(plot_args);
-    if(res) Py_DECREF(res);
+	template<typename NumericX, typename NumericY, typename NumericU, typename NumericW>
+	bool quiver(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::vector<NumericU> &u, const std::vector<NumericW> &w, const std::map<std::string, std::string> &keywords = { }) {
+		assert(x.size() == y.size() && x.size() == u.size() && u.size() == w.size());
 
-    return res;
-}
+		detail::_interpreter::get();
 
-template<typename NumericX, typename NumericY>
-bool semilogy(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::string& s = "")
-{
-    assert(x.size() == y.size());
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
+		PyObject *uarray = detail::get_array(u);
+		PyObject *warray = detail::get_array(w);
 
-    detail::_interpreter::get();
+		PyObject *plot_args = PyTuple_New(4);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, uarray);
+		PyTuple_SetItem(plot_args, 3, warray);
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* pystring = PyString_FromString(s.c_str());
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_quiver, plot_args, kwargs);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_semilogy, plot_args);
+		return res;
+	}
 
-    Py_DECREF(plot_args);
-    if(res) Py_DECREF(res);
+	template<typename NumericX, typename NumericY>
+	bool stem(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::string &s = "") {
+		assert(x.size() == y.size());
 
-    return res;
-}
+		detail::_interpreter::get();
 
-template<typename NumericX, typename NumericY>
-bool loglog(const std::vector<NumericX>& x, const std::vector<NumericY>& y, const std::string& s = "")
-{
-    assert(x.size() == y.size());
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    detail::_interpreter::get();
+		PyObject *pystring = PyString_FromString(s.c_str());
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    PyObject* pystring = PyString_FromString(s.c_str());
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_stem, plot_args);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_loglog, plot_args);
+		return res;
+	}
 
-    Py_DECREF(plot_args);
-    if(res) Py_DECREF(res);
+	template<typename NumericX, typename NumericY>
+	bool semilogx(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::string &s = "") {
+		assert(x.size() == y.size());
 
-    return res;
-}
+		detail::_interpreter::get();
 
-template<typename NumericX, typename NumericY>
-bool errorbar(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::vector<NumericX> &yerr, const std::map<std::string, std::string> &keywords = {})
-{
-    assert(x.size() == y.size());
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    detail::_interpreter::get();
+		PyObject *pystring = PyString_FromString(s.c_str());
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
-    PyObject* yerrarray = detail::get_array(yerr);
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-    }
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_semilogx, plot_args);
 
-    PyDict_SetItemString(kwargs, "yerr", yerrarray);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject *plot_args = PyTuple_New(2);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
+		return res;
+	}
 
-    PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_errorbar, plot_args, kwargs);
+	template<typename NumericX, typename NumericY>
+	bool semilogy(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::string &s = "") {
+		assert(x.size() == y.size());
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
+		detail::_interpreter::get();
 
-    if (res)
-        Py_DECREF(res);
-    else
-        throw std::runtime_error("Call to errorbar() failed.");
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    return res;
-}
+		PyObject *pystring = PyString_FromString(s.c_str());
 
-template<typename Numeric>
-bool named_plot(const std::string& name, const std::vector<Numeric>& y, const std::string& format = "")
-{
-    detail::_interpreter::get();
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_semilogy, plot_args);
 
-    PyObject* yarray = detail::get_array(y);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* pystring = PyString_FromString(format.c_str());
+		return res;
+	}
 
-    PyObject* plot_args = PyTuple_New(2);
+	template<typename NumericX, typename NumericY>
+	bool loglog(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::string &s = "") {
+		assert(x.size() == y.size());
 
-    PyTuple_SetItem(plot_args, 0, yarray);
-    PyTuple_SetItem(plot_args, 1, pystring);
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res) Py_DECREF(res);
+		PyObject *pystring = PyString_FromString(s.c_str());
 
-    return res;
-}
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-template<typename Numeric>
-bool named_plot(const std::string& name, const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::string& format = "")
-{
-    detail::_interpreter::get();
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_loglog, plot_args);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		return res;
+	}
 
-    PyObject* pystring = PyString_FromString(format.c_str());
+	template<typename NumericX, typename NumericY>
+	bool errorbar(const std::vector<NumericX> &x, const std::vector<NumericY> &y, const std::vector<NumericX> &yerr, const std::map<std::string, std::string> &keywords = { }) {
+		assert(x.size() == y.size());
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
+		PyObject *yerrarray = detail::get_array(yerr);
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res) Py_DECREF(res);
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    return res;
-}
+		PyDict_SetItemString(kwargs, "yerr", yerrarray);
 
-template<typename Numeric>
-bool named_semilogx(const std::string& name, const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::string& format = "")
-{
-    detail::_interpreter::get();
+		PyObject *plot_args = PyTuple_New(2);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_errorbar, plot_args, kwargs);
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
 
-    PyObject* pystring = PyString_FromString(format.c_str());
+		if (res) Py_DECREF(res);
+		else throw std::runtime_error("Call to errorbar() failed.");
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		return res;
+	}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_semilogx, plot_args, kwargs);
+	template<typename Numeric>
+	bool named_plot(const std::string &name, const std::vector<Numeric> &y, const std::string &format = "") {
+		detail::_interpreter::get();
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res) Py_DECREF(res);
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-    return res;
-}
+		PyObject *yarray = detail::get_array(y);
 
-template<typename Numeric>
-bool named_semilogy(const std::string& name, const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::string& format = "")
-{
-    detail::_interpreter::get();
+		PyObject *pystring = PyString_FromString(format.c_str());
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+		PyObject *plot_args = PyTuple_New(2);
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyTuple_SetItem(plot_args, 0, yarray);
+		PyTuple_SetItem(plot_args, 1, pystring);
 
-    PyObject* pystring = PyString_FromString(format.c_str());
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_semilogy, plot_args, kwargs);
+		return res;
+	}
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res) Py_DECREF(res);
+	template<typename Numeric>
+	bool named_plot(const std::string &name, const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::string &format = "") {
+		detail::_interpreter::get();
 
-    return res;
-}
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-template<typename Numeric>
-bool named_loglog(const std::string& name, const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::string& format = "")
-{
-    detail::_interpreter::get();
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+		PyObject *pystring = PyString_FromString(format.c_str());
 
-    PyObject* xarray = detail::get_array(x);
-    PyObject* yarray = detail::get_array(y);
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    PyObject* pystring = PyString_FromString(format.c_str());
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
 
-    PyObject* plot_args = PyTuple_New(3);
-    PyTuple_SetItem(plot_args, 0, xarray);
-    PyTuple_SetItem(plot_args, 1, yarray);
-    PyTuple_SetItem(plot_args, 2, pystring);
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_loglog, plot_args, kwargs);
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    Py_DECREF(kwargs);
-    Py_DECREF(plot_args);
-    if (res) Py_DECREF(res);
+		return res;
+	}
 
-    return res;
-}
+	template<typename Numeric>
+	bool named_semilogx(const std::string &name, const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::string &format = "") {
+		detail::_interpreter::get();
 
-template<typename Numeric>
-bool plot(const std::vector<Numeric>& y, const std::string& format = "")
-{
-    std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
-    return plot(x,y,format);
-}
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-template<typename Numeric>
-bool plot(const std::vector<Numeric>& y, const std::map<std::string, std::string>& keywords)
-{
-    std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
-    return plot(x,y,keywords);
-}
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-template<typename Numeric>
-bool stem(const std::vector<Numeric>& y, const std::string& format = "")
-{
-    std::vector<Numeric> x(y.size());
-    for (size_t i = 0; i < x.size(); ++i) x.at(i) = i;
-    return stem(x, y, format);
-}
+		PyObject *pystring = PyString_FromString(format.c_str());
 
-template<typename Numeric>
-void text(Numeric x, Numeric y, const std::string& s = "")
-{
-    detail::_interpreter::get();
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    PyObject* args = PyTuple_New(3);
-    PyTuple_SetItem(args, 0, PyFloat_FromDouble(x));
-    PyTuple_SetItem(args, 1, PyFloat_FromDouble(y));
-    PyTuple_SetItem(args, 2, PyString_FromString(s.c_str()));
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_semilogx, plot_args, kwargs);
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_text, args);
-    if(!res) throw std::runtime_error("Call to text() failed.");
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		return res;
+	}
 
-inline void colorbar(PyObject* mappable = NULL, const std::map<std::string, float>& keywords = {})
-{
-    if (mappable == NULL)
-        throw std::runtime_error("Must call colorbar with PyObject* returned from an image, contour, surface, etc.");
+	template<typename Numeric>
+	bool named_semilogy(const std::string &name, const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::string &format = "") {
+		detail::_interpreter::get();
 
-    detail::_interpreter::get();
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, mappable);
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, float>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyFloat_FromDouble(it->second));
-    }
+		PyObject *pystring = PyString_FromString(format.c_str());
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_colorbar, args, kwargs);
-    if(!res) throw std::runtime_error("Call to colorbar() failed.");
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(res);
-}
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_semilogy, plot_args, kwargs);
 
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-inline long figure(long number = -1)
-{
-    detail::_interpreter::get();
+		return res;
+	}
 
-    PyObject *res;
-    if (number == -1)
-        res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
-    else {
-        assert(number > 0);
+	template<typename Numeric>
+	bool named_loglog(const std::string &name, const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::string &format = "") {
+		detail::_interpreter::get();
 
-        // Make sure interpreter is initialised
-        detail::_interpreter::get();
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-        PyObject *args = PyTuple_New(1);
-        PyTuple_SetItem(args, 0, PyLong_FromLong(number));
-        res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, args);
-        Py_DECREF(args);
-    }
+		PyObject *xarray = detail::get_array(x);
+		PyObject *yarray = detail::get_array(y);
 
-    if(!res) throw std::runtime_error("Call to figure() failed.");
+		PyObject *pystring = PyString_FromString(format.c_str());
 
-    PyObject* num = PyObject_GetAttrString(res, "number");
-    if (!num) throw std::runtime_error("Could not get number attribute of figure object");
-    const long figureNumber = PyLong_AsLong(num);
+		PyObject *plot_args = PyTuple_New(3);
+		PyTuple_SetItem(plot_args, 0, xarray);
+		PyTuple_SetItem(plot_args, 1, yarray);
+		PyTuple_SetItem(plot_args, 2, pystring);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_loglog, plot_args, kwargs);
 
-    Py_DECREF(num);
-    Py_DECREF(res);
+		Py_DECREF(kwargs);
+		Py_DECREF(plot_args);
+		if (res) Py_DECREF(res);
 
-    return figureNumber;
-}
+		return res;
+	}
 
-inline bool fignum_exists(long number)
-{
-    detail::_interpreter::get();
+	template<typename Numeric>
+	bool plot(const std::vector<Numeric> &y, const std::string &format = "") {
+		std::vector<Numeric> x(y.size());
+		for (size_t i = 0; i < x.size(); ++i)
+			x.at(i) = i;
+		return plot(x, y, format);
+	}
 
-    PyObject *args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, PyLong_FromLong(number));
-    PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_fignum_exists, args);
-    if(!res) throw std::runtime_error("Call to fignum_exists() failed.");
+	template<typename Numeric>
+	bool plot(const std::vector<Numeric> &y, const std::map<std::string, std::string> &keywords) {
+		std::vector<Numeric> x(y.size());
+		for (size_t i = 0; i < x.size(); ++i)
+			x.at(i) = i;
+		return plot(x, y, keywords);
+	}
 
-    bool ret = PyObject_IsTrue(res);
-    Py_DECREF(res);
-    Py_DECREF(args);
+	template<typename Numeric>
+	bool stem(const std::vector<Numeric> &y, const std::string &format = "") {
+		std::vector<Numeric> x(y.size());
+		for (size_t i = 0; i < x.size(); ++i)
+			x.at(i) = i;
+		return stem(x, y, format);
+	}
 
-    return ret;
-}
+	template<typename Numeric>
+	void text(Numeric x, Numeric y, const std::string &s = "") {
+		detail::_interpreter::get();
 
-inline void figure_size(size_t w, size_t h)
-{
-    detail::_interpreter::get();
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, PyFloat_FromDouble(x));
+		PyTuple_SetItem(args, 1, PyFloat_FromDouble(y));
+		PyTuple_SetItem(args, 2, PyString_FromString(s.c_str()));
 
-    const size_t dpi = 100;
-    PyObject* size = PyTuple_New(2);
-    PyTuple_SetItem(size, 0, PyFloat_FromDouble((double)w / dpi));
-    PyTuple_SetItem(size, 1, PyFloat_FromDouble((double)h / dpi));
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_text, args);
+		if (!res) throw std::runtime_error("Call to text() failed.");
 
-    PyObject* kwargs = PyDict_New();
-    PyDict_SetItemString(kwargs, "figsize", size);
-    PyDict_SetItemString(kwargs, "dpi", PyLong_FromSize_t(dpi));
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_figure,
-            detail::_interpreter::get().s_python_empty_tuple, kwargs);
+	inline void colorbar(PyObject *mappable = NULL, const std::map<std::string, float> &keywords = { }) {
+		if (mappable == NULL) throw std::runtime_error("Must call colorbar with PyObject* returned from an image, contour, surface, etc.");
 
-    Py_DECREF(kwargs);
+		detail::_interpreter::get();
 
-    if(!res) throw std::runtime_error("Call to figure_size() failed.");
-    Py_DECREF(res);
-}
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, mappable);
 
-inline void legend()
-{
-    detail::_interpreter::get();
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, float>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyFloat_FromDouble(it->second));
+		}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_legend, detail::_interpreter::get().s_python_empty_tuple);
-    if(!res) throw std::runtime_error("Call to legend() failed.");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_colorbar, args, kwargs);
+		if (!res) throw std::runtime_error("Call to colorbar() failed.");
 
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		Py_DECREF(res);
+	}
 
-template<typename Numeric>
-void ylim(Numeric left, Numeric right)
-{
-    detail::_interpreter::get();
+	inline long figure(long number = -1) {
+		detail::_interpreter::get();
 
-    PyObject* list = PyList_New(2);
-    PyList_SetItem(list, 0, PyFloat_FromDouble(left));
-    PyList_SetItem(list, 1, PyFloat_FromDouble(right));
+		PyObject *res;
+		if (number == -1) res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple);
+		else {
+			assert(number > 0);
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, list);
+			// Make sure interpreter is initialised
+			detail::_interpreter::get();
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_ylim, args);
-    if(!res) throw std::runtime_error("Call to ylim() failed.");
+			PyObject *args = PyTuple_New(1);
+			PyTuple_SetItem(args, 0, PyLong_FromLong(number));
+			res = PyObject_CallObject(detail::_interpreter::get().s_python_function_figure, args);
+			Py_DECREF(args);
+		}
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		if (!res) throw std::runtime_error("Call to figure() failed.");
 
-template<typename Numeric>
-void xlim(Numeric left, Numeric right)
-{
-    detail::_interpreter::get();
+		PyObject *num = PyObject_GetAttrString(res, "number");
+		if (!num) throw std::runtime_error("Could not get number attribute of figure object");
+		const long figureNumber = PyLong_AsLong(num);
 
-    PyObject* list = PyList_New(2);
-    PyList_SetItem(list, 0, PyFloat_FromDouble(left));
-    PyList_SetItem(list, 1, PyFloat_FromDouble(right));
+		Py_DECREF(num);
+		Py_DECREF(res);
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, list);
+		return figureNumber;
+	}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_xlim, args);
-    if(!res) throw std::runtime_error("Call to xlim() failed.");
+	inline bool fignum_exists(long number) {
+		detail::_interpreter::get();
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, PyLong_FromLong(number));
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_fignum_exists, args);
+		if (!res) throw std::runtime_error("Call to fignum_exists() failed.");
 
+		bool ret = PyObject_IsTrue(res);
+		Py_DECREF(res);
+		Py_DECREF(args);
 
-inline double* xlim()
-{
-    detail::_interpreter::get();
+		return ret;
+	}
 
-    PyObject* args = PyTuple_New(0);
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_xlim, args);
-    PyObject* left = PyTuple_GetItem(res,0);
-    PyObject* right = PyTuple_GetItem(res,1);
+	inline void figure_size(size_t w, size_t h) {
+		detail::_interpreter::get();
 
-    double* arr = new double[2];
-    arr[0] = PyFloat_AsDouble(left);
-    arr[1] = PyFloat_AsDouble(right);
+		const size_t dpi = 100;
+		PyObject *size = PyTuple_New(2);
+		PyTuple_SetItem(size, 0, PyFloat_FromDouble((double) w / dpi));
+		PyTuple_SetItem(size, 1, PyFloat_FromDouble((double) h / dpi));
 
-    if(!res) throw std::runtime_error("Call to xlim() failed.");
+		PyObject *kwargs = PyDict_New();
+		PyDict_SetItemString(kwargs, "figsize", size);
+		PyDict_SetItemString(kwargs, "dpi", PyLong_FromSize_t(dpi));
 
-    Py_DECREF(res);
-    return arr;
-}
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_figure, detail::_interpreter::get().s_python_empty_tuple, kwargs);
 
+		Py_DECREF(kwargs);
 
-inline double* ylim()
-{
-    detail::_interpreter::get();
+		if (!res) throw std::runtime_error("Call to figure_size() failed.");
+		Py_DECREF(res);
+	}
 
-    PyObject* args = PyTuple_New(0);
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_ylim, args);
-    PyObject* left = PyTuple_GetItem(res,0);
-    PyObject* right = PyTuple_GetItem(res,1);
+	inline void legend() {
+		detail::_interpreter::get();
 
-    double* arr = new double[2];
-    arr[0] = PyFloat_AsDouble(left);
-    arr[1] = PyFloat_AsDouble(right);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_legend, detail::_interpreter::get().s_python_empty_tuple);
+		if (!res) throw std::runtime_error("Call to legend() failed.");
 
-    if(!res) throw std::runtime_error("Call to ylim() failed.");
+		Py_DECREF(res);
+	}
 
-    Py_DECREF(res);
-    return arr;
-}
+	template<typename Numeric>
+	void ylim(Numeric left, Numeric right) {
+		detail::_interpreter::get();
 
-template<typename Numeric>
-inline void xticks(const std::vector<Numeric> &ticks, const std::vector<std::string> &labels = {}, const std::map<std::string, std::string>& keywords = {})
-{
-    assert(labels.size() == 0 || ticks.size() == labels.size());
+		PyObject *list = PyList_New(2);
+		PyList_SetItem(list, 0, PyFloat_FromDouble(left));
+		PyList_SetItem(list, 1, PyFloat_FromDouble(right));
 
-    detail::_interpreter::get();
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, list);
 
-    // using numpy array
-    PyObject* ticksarray = detail::get_array(ticks);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_ylim, args);
+		if (!res) throw std::runtime_error("Call to ylim() failed.");
 
-    PyObject* args;
-    if(labels.size() == 0) {
-        // construct positional args
-        args = PyTuple_New(1);
-        PyTuple_SetItem(args, 0, ticksarray);
-    } else {
-        // make tuple of tick labels
-        PyObject* labelstuple = PyTuple_New(labels.size());
-        for (size_t i = 0; i < labels.size(); i++)
-            PyTuple_SetItem(labelstuple, i, PyUnicode_FromString(labels[i].c_str()));
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-        // construct positional args
-        args = PyTuple_New(2);
-        PyTuple_SetItem(args, 0, ticksarray);
-        PyTuple_SetItem(args, 1, labelstuple);
-    }
+	template<typename Numeric>
+	void xlim(Numeric left, Numeric right) {
+		detail::_interpreter::get();
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-    }
+		PyObject *list = PyList_New(2);
+		PyList_SetItem(list, 0, PyFloat_FromDouble(left));
+		PyList_SetItem(list, 1, PyFloat_FromDouble(right));
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_xticks, args, kwargs);
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, list);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if(!res) throw std::runtime_error("Call to xticks() failed");
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_xlim, args);
+		if (!res) throw std::runtime_error("Call to xlim() failed.");
 
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-template<typename Numeric>
-inline void xticks(const std::vector<Numeric> &ticks, const std::map<std::string, std::string>& keywords)
-{
-    xticks(ticks, {}, keywords);
-}
+	inline double* xlim() {
+		detail::_interpreter::get();
 
-template<typename Numeric>
-inline void yticks(const std::vector<Numeric> &ticks, const std::vector<std::string> &labels = {}, const std::map<std::string, std::string>& keywords = {})
-{
-    assert(labels.size() == 0 || ticks.size() == labels.size());
+		PyObject *args = PyTuple_New(0);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_xlim, args);
+		PyObject *left = PyTuple_GetItem(res, 0);
+		PyObject *right = PyTuple_GetItem(res, 1);
 
-    detail::_interpreter::get();
+		double *arr = new double[2];
+		arr[0] = PyFloat_AsDouble(left);
+		arr[1] = PyFloat_AsDouble(right);
 
-    // using numpy array
-    PyObject* ticksarray = detail::get_array(ticks);
+		if (!res) throw std::runtime_error("Call to xlim() failed.");
 
-    PyObject* args;
-    if(labels.size() == 0) {
-        // construct positional args
-        args = PyTuple_New(1);
-        PyTuple_SetItem(args, 0, ticksarray);
-    } else {
-        // make tuple of tick labels
-        PyObject* labelstuple = PyTuple_New(labels.size());
-        for (size_t i = 0; i < labels.size(); i++)
-            PyTuple_SetItem(labelstuple, i, PyUnicode_FromString(labels[i].c_str()));
+		Py_DECREF(res);
+		return arr;
+	}
 
-        // construct positional args
-        args = PyTuple_New(2);
-        PyTuple_SetItem(args, 0, ticksarray);
-        PyTuple_SetItem(args, 1, labelstuple);
-    }
+	inline double* ylim() {
+		detail::_interpreter::get();
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-    }
+		PyObject *args = PyTuple_New(0);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_ylim, args);
+		PyObject *left = PyTuple_GetItem(res, 0);
+		PyObject *right = PyTuple_GetItem(res, 1);
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_yticks, args, kwargs);
+		double *arr = new double[2];
+		arr[0] = PyFloat_AsDouble(left);
+		arr[1] = PyFloat_AsDouble(right);
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if(!res) throw std::runtime_error("Call to yticks() failed");
+		if (!res) throw std::runtime_error("Call to ylim() failed.");
 
-    Py_DECREF(res);
-}
+		Py_DECREF(res);
+		return arr;
+	}
 
-template<typename Numeric>
-inline void yticks(const std::vector<Numeric> &ticks, const std::map<std::string, std::string>& keywords)
-{
-    yticks(ticks, {}, keywords);
-}
+	template<typename Numeric>
+	inline void xticks(const std::vector<Numeric> &ticks, const std::vector<std::string> &labels = { }, const std::map<std::string, std::string> &keywords = { }) {
+		assert(labels.size() == 0 || ticks.size() == labels.size());
 
-inline void tick_params(const std::map<std::string, std::string>& keywords, const std::string axis = "both")
-{
-  detail::_interpreter::get();
+		detail::_interpreter::get();
 
-  // construct positional args
-  PyObject* args;
-  args = PyTuple_New(1);
-  PyTuple_SetItem(args, 0, PyString_FromString(axis.c_str()));
+		// using numpy array
+		PyObject *ticksarray = detail::get_array(ticks);
 
-  // construct keyword args
-  PyObject* kwargs = PyDict_New();
-  for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-  {
-    PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-  }
+		PyObject *args;
+		if (labels.size() == 0) {
+			// construct positional args
+			args = PyTuple_New(1);
+			PyTuple_SetItem(args, 0, ticksarray);
+		} else {
+			// make tuple of tick labels
+			PyObject *labelstuple = PyTuple_New(labels.size());
+			for (size_t i = 0; i < labels.size(); i++)
+				PyTuple_SetItem(labelstuple, i, PyUnicode_FromString(labels[i].c_str()));
 
+			// construct positional args
+			args = PyTuple_New(2);
+			PyTuple_SetItem(args, 0, ticksarray);
+			PyTuple_SetItem(args, 1, labelstuple);
+		}
 
-  PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_tick_params, args, kwargs);
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-  Py_DECREF(args);
-  Py_DECREF(kwargs);
-  if (!res) throw std::runtime_error("Call to tick_params() failed");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_xticks, args, kwargs);
 
-  Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (!res) throw std::runtime_error("Call to xticks() failed");
 
-inline void subplot(long nrows, long ncols, long plot_number)
-{
-    detail::_interpreter::get();
-    
-    // construct positional args
-    PyObject* args = PyTuple_New(3);
-    PyTuple_SetItem(args, 0, PyFloat_FromDouble(nrows));
-    PyTuple_SetItem(args, 1, PyFloat_FromDouble(ncols));
-    PyTuple_SetItem(args, 2, PyFloat_FromDouble(plot_number));
+		Py_DECREF(res);
+	}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_subplot, args);
-    if(!res) throw std::runtime_error("Call to subplot() failed.");
+	template<typename Numeric>
+	inline void xticks(const std::vector<Numeric> &ticks, const std::map<std::string, std::string> &keywords) {
+		xticks(ticks, { }, keywords);
+	}
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+	template<typename Numeric>
+	inline void yticks(const std::vector<Numeric> &ticks, const std::vector<std::string> &labels = { }, const std::map<std::string, std::string> &keywords = { }) {
+		assert(labels.size() == 0 || ticks.size() == labels.size());
 
-inline void subplot2grid(long nrows, long ncols, long rowid=0, long colid=0, long rowspan=1, long colspan=1)
-{
-    detail::_interpreter::get();
+		detail::_interpreter::get();
 
-    PyObject* shape = PyTuple_New(2);
-    PyTuple_SetItem(shape, 0, PyLong_FromLong(nrows));
-    PyTuple_SetItem(shape, 1, PyLong_FromLong(ncols));
+		// using numpy array
+		PyObject *ticksarray = detail::get_array(ticks);
 
-    PyObject* loc = PyTuple_New(2);
-    PyTuple_SetItem(loc, 0, PyLong_FromLong(rowid));
-    PyTuple_SetItem(loc, 1, PyLong_FromLong(colid));
+		PyObject *args;
+		if (labels.size() == 0) {
+			// construct positional args
+			args = PyTuple_New(1);
+			PyTuple_SetItem(args, 0, ticksarray);
+		} else {
+			// make tuple of tick labels
+			PyObject *labelstuple = PyTuple_New(labels.size());
+			for (size_t i = 0; i < labels.size(); i++)
+				PyTuple_SetItem(labelstuple, i, PyUnicode_FromString(labels[i].c_str()));
 
-    PyObject* args = PyTuple_New(4);
-    PyTuple_SetItem(args, 0, shape);
-    PyTuple_SetItem(args, 1, loc);
-    PyTuple_SetItem(args, 2, PyLong_FromLong(rowspan));
-    PyTuple_SetItem(args, 3, PyLong_FromLong(colspan));
+			// construct positional args
+			args = PyTuple_New(2);
+			PyTuple_SetItem(args, 0, ticksarray);
+			PyTuple_SetItem(args, 1, labelstuple);
+		}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_subplot2grid, args);
-    if(!res) throw std::runtime_error("Call to subplot2grid() failed.");
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    Py_DECREF(shape);
-    Py_DECREF(loc);
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_yticks, args, kwargs);
 
-inline void title(const std::string &titlestr, const std::map<std::string, std::string> &keywords = {})
-{
-    detail::_interpreter::get();
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (!res) throw std::runtime_error("Call to yticks() failed");
 
-    PyObject* pytitlestr = PyString_FromString(titlestr.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pytitlestr);
+		Py_DECREF(res);
+	}
 
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+	template<typename Numeric>
+	inline void yticks(const std::vector<Numeric> &ticks, const std::map<std::string, std::string> &keywords) {
+		yticks(ticks, { }, keywords);
+	}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_title, args, kwargs);
-    if(!res) throw std::runtime_error("Call to title() failed.");
+	inline void tick_params(const std::map<std::string, std::string> &keywords, const std::string axis = "both") {
+		detail::_interpreter::get();
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(res);
-}
+		// construct positional args
+		PyObject *args;
+		args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, PyString_FromString(axis.c_str()));
 
-inline void suptitle(const std::string &suptitlestr, const std::map<std::string, std::string> &keywords = {})
-{
-    detail::_interpreter::get();
-    
-    PyObject* pysuptitlestr = PyString_FromString(suptitlestr.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pysuptitlestr);
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_tick_params, args, kwargs);
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_suptitle, args, kwargs);
-    if(!res) throw std::runtime_error("Call to suptitle() failed.");
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (!res) throw std::runtime_error("Call to tick_params() failed");
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(res);
-}
+		Py_DECREF(res);
+	}
 
-inline void axis(const std::string &axisstr)
-{
-    detail::_interpreter::get();
+	inline void subplot(long nrows, long ncols, long plot_number) {
+		detail::_interpreter::get();
 
-    PyObject* str = PyString_FromString(axisstr.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, str);
+		// construct positional args
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, PyFloat_FromDouble(nrows));
+		PyTuple_SetItem(args, 1, PyFloat_FromDouble(ncols));
+		PyTuple_SetItem(args, 2, PyFloat_FromDouble(plot_number));
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_axis, args);
-    if(!res) throw std::runtime_error("Call to title() failed.");
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_subplot, args);
+		if (!res) throw std::runtime_error("Call to subplot() failed.");
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-inline void axvline(double x, double ymin = 0., double ymax = 1., const std::map<std::string, std::string>& keywords = std::map<std::string, std::string>())
-{
-    detail::_interpreter::get();
+	inline void subplot2grid(long nrows, long ncols, long rowid = 0, long colid = 0, long rowspan = 1, long colspan = 1) {
+		detail::_interpreter::get();
 
-    // construct positional args
-    PyObject* args = PyTuple_New(3);
-    PyTuple_SetItem(args, 0, PyFloat_FromDouble(x));
-    PyTuple_SetItem(args, 1, PyFloat_FromDouble(ymin));
-    PyTuple_SetItem(args, 2, PyFloat_FromDouble(ymax));
+		PyObject *shape = PyTuple_New(2);
+		PyTuple_SetItem(shape, 0, PyLong_FromLong(nrows));
+		PyTuple_SetItem(shape, 1, PyLong_FromLong(ncols));
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
-    }
+		PyObject *loc = PyTuple_New(2);
+		PyTuple_SetItem(loc, 0, PyLong_FromLong(rowid));
+		PyTuple_SetItem(loc, 1, PyLong_FromLong(colid));
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_axvline, args, kwargs);
+		PyObject *args = PyTuple_New(4);
+		PyTuple_SetItem(args, 0, shape);
+		PyTuple_SetItem(args, 1, loc);
+		PyTuple_SetItem(args, 2, PyLong_FromLong(rowspan));
+		PyTuple_SetItem(args, 3, PyLong_FromLong(colspan));
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_subplot2grid, args);
+		if (!res) throw std::runtime_error("Call to subplot2grid() failed.");
 
-    if(res) Py_DECREF(res);
-}
+		Py_DECREF(shape);
+		Py_DECREF(loc);
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-inline void xlabel(const std::string &str, const std::map<std::string, std::string> &keywords = {})
-{
-    detail::_interpreter::get();
+	inline void title(const std::string &titlestr, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* pystr = PyString_FromString(str.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pystr);
+		PyObject *pytitlestr = PyString_FromString(titlestr.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pytitlestr);
 
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_xlabel, args, kwargs);
-    if(!res) throw std::runtime_error("Call to xlabel() failed.");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_title, args, kwargs);
+		if (!res) throw std::runtime_error("Call to title() failed.");
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		Py_DECREF(res);
+	}
 
-inline void ylabel(const std::string &str, const std::map<std::string, std::string>& keywords = {})
-{
-    detail::_interpreter::get();
+	inline void suptitle(const std::string &suptitlestr, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* pystr = PyString_FromString(str.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pystr);
+		PyObject *pysuptitlestr = PyString_FromString(suptitlestr.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pysuptitlestr);
 
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_ylabel, args, kwargs);
-    if(!res) throw std::runtime_error("Call to ylabel() failed.");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_suptitle, args, kwargs);
+		if (!res) throw std::runtime_error("Call to suptitle() failed.");
 
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		Py_DECREF(res);
+	}
 
-inline void set_zlabel(const std::string &str, const std::map<std::string, std::string>& keywords = {})
-{
-    detail::_interpreter::get();
+	inline void axis(const std::string &axisstr) {
+		detail::_interpreter::get();
 
-    // Same as with plot_surface: We lazily load the modules here the first time 
-    // this function is called because I'm not sure that we can assume "matplotlib 
-    // installed" implies "mpl_toolkits installed" on all platforms, and we don't 
-    // want to require it for people who don't need 3d plots.
-    static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
-    if (!mpl_toolkitsmod) {
-        PyObject* mpl_toolkits = PyString_FromString("mpl_toolkits");
-        PyObject* axis3d = PyString_FromString("mpl_toolkits.mplot3d");
-        if (!mpl_toolkits || !axis3d) { throw std::runtime_error("couldnt create string"); }
+		PyObject *str = PyString_FromString(axisstr.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, str);
 
-        mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
-        Py_DECREF(mpl_toolkits);
-        if (!mpl_toolkitsmod) { throw std::runtime_error("Error loading module mpl_toolkits!"); }
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_axis, args);
+		if (!res) throw std::runtime_error("Call to title() failed.");
 
-        axis3dmod = PyImport_Import(axis3d);
-        Py_DECREF(axis3d);
-        if (!axis3dmod) { throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!"); }
-    }
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-    PyObject* pystr = PyString_FromString(str.c_str());
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pystr);
+	inline void axvline(double x, double ymin = 0., double ymax = 1., const std::map<std::string, std::string> &keywords = std::map<std::string, std::string>()) {
+		detail::_interpreter::get();
 
-    PyObject* kwargs = PyDict_New();
-    for (auto it = keywords.begin(); it != keywords.end(); ++it) {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+		// construct positional args
+		PyObject *args = PyTuple_New(3);
+		PyTuple_SetItem(args, 0, PyFloat_FromDouble(x));
+		PyTuple_SetItem(args, 1, PyFloat_FromDouble(ymin));
+		PyTuple_SetItem(args, 2, PyFloat_FromDouble(ymax));
 
-    PyObject *ax =
-    PyObject_CallObject(detail::_interpreter::get().s_python_function_gca,
-      detail::_interpreter::get().s_python_empty_tuple);
-    if (!ax) throw std::runtime_error("Call to gca() failed.");
-    Py_INCREF(ax);
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyString_FromString(it->second.c_str()));
+		}
 
-    PyObject *zlabel = PyObject_GetAttrString(ax, "set_zlabel");
-    if (!zlabel) throw std::runtime_error("Attribute set_zlabel not found.");
-    Py_INCREF(zlabel);
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_axvline, args, kwargs);
 
-    PyObject *res = PyObject_Call(zlabel, args, kwargs);
-    if (!res) throw std::runtime_error("Call to set_zlabel() failed.");
-    Py_DECREF(zlabel);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
 
-    Py_DECREF(ax);
-    Py_DECREF(args);
-    Py_DECREF(kwargs);
-    if (res) Py_DECREF(res);
-}
+		if (res) Py_DECREF(res);
+	}
 
-inline void grid(bool flag)
-{
-    detail::_interpreter::get();
+	inline void xlabel(const std::string &str, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* pyflag = flag ? Py_True : Py_False;
-    Py_INCREF(pyflag);
+		PyObject *pystr = PyString_FromString(str.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pystr);
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pyflag);
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_grid, args);
-    if(!res) throw std::runtime_error("Call to grid() failed.");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_xlabel, args, kwargs);
+		if (!res) throw std::runtime_error("Call to xlabel() failed.");
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		Py_DECREF(res);
+	}
 
-inline void show(const bool block = true)
-{
-    detail::_interpreter::get();
+	inline void ylabel(const std::string &str, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* res;
-    if(block)
-    {
-        res = PyObject_CallObject(
-                detail::_interpreter::get().s_python_function_show,
-                detail::_interpreter::get().s_python_empty_tuple);
-    }
-    else
-    {
-        PyObject *kwargs = PyDict_New();
-        PyDict_SetItemString(kwargs, "block", Py_False);
-        res = PyObject_Call( detail::_interpreter::get().s_python_function_show, detail::_interpreter::get().s_python_empty_tuple, kwargs);
-       Py_DECREF(kwargs);
-    }
+		PyObject *pystr = PyString_FromString(str.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pystr);
 
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    if (!res) throw std::runtime_error("Call to show() failed.");
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_ylabel, args, kwargs);
+		if (!res) throw std::runtime_error("Call to ylabel() failed.");
 
-    Py_DECREF(res);
-}
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		Py_DECREF(res);
+	}
 
-inline void close()
-{
-    detail::_interpreter::get();
+	inline void set_zlabel(const std::string &str, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_CallObject(
-            detail::_interpreter::get().s_python_function_close,
-            detail::_interpreter::get().s_python_empty_tuple);
+		// Same as with plot_surface: We lazily load the modules here the first time 
+		// this function is called because I'm not sure that we can assume "matplotlib 
+		// installed" implies "mpl_toolkits installed" on all platforms, and we don't 
+		// want to require it for people who don't need 3d plots.
+		static PyObject *mpl_toolkitsmod = nullptr, *axis3dmod = nullptr;
+		if (!mpl_toolkitsmod) {
+			PyObject *mpl_toolkits = PyString_FromString("mpl_toolkits");
+			PyObject *axis3d = PyString_FromString("mpl_toolkits.mplot3d");
+			if (!mpl_toolkits || !axis3d) {
+				throw std::runtime_error("couldnt create string");
+			}
 
-    if (!res) throw std::runtime_error("Call to close() failed.");
+			mpl_toolkitsmod = PyImport_Import(mpl_toolkits);
+			Py_DECREF(mpl_toolkits);
+			if (!mpl_toolkitsmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits!");
+			}
 
-    Py_DECREF(res);
-}
+			axis3dmod = PyImport_Import(axis3d);
+			Py_DECREF(axis3d);
+			if (!axis3dmod) {
+				throw std::runtime_error("Error loading module mpl_toolkits.mplot3d!");
+			}
+		}
 
-inline void xkcd() {
-    detail::_interpreter::get();
+		PyObject *pystr = PyString_FromString(str.c_str());
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pystr);
 
-    PyObject* res;
-    PyObject *kwargs = PyDict_New();
+		PyObject *kwargs = PyDict_New();
+		for (auto it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
 
-    res = PyObject_Call(detail::_interpreter::get().s_python_function_xkcd,
-            detail::_interpreter::get().s_python_empty_tuple, kwargs);
+		PyObject *ax = PyObject_CallObject(detail::_interpreter::get().s_python_function_gca, detail::_interpreter::get().s_python_empty_tuple);
+		if (!ax) throw std::runtime_error("Call to gca() failed.");
+		Py_INCREF(ax);
 
-    Py_DECREF(kwargs);
+		PyObject *zlabel = PyObject_GetAttrString(ax, "set_zlabel");
+		if (!zlabel) throw std::runtime_error("Attribute set_zlabel not found.");
+		Py_INCREF(zlabel);
 
-    if (!res)
-        throw std::runtime_error("Call to show() failed.");
+		PyObject *res = PyObject_Call(zlabel, args, kwargs);
+		if (!res) throw std::runtime_error("Call to set_zlabel() failed.");
+		Py_DECREF(zlabel);
 
-    Py_DECREF(res);
-}
+		Py_DECREF(ax);
+		Py_DECREF(args);
+		Py_DECREF(kwargs);
+		if (res) Py_DECREF(res);
+	}
 
-inline void draw()
-{
-    detail::_interpreter::get();
+	inline void grid(bool flag) {
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_CallObject(
-        detail::_interpreter::get().s_python_function_draw,
-        detail::_interpreter::get().s_python_empty_tuple);
+		PyObject *pyflag = flag ? Py_True : Py_False;
+		Py_INCREF(pyflag);
 
-    if (!res) throw std::runtime_error("Call to draw() failed.");
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pyflag);
 
-    Py_DECREF(res);
-}
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_grid, args);
+		if (!res) throw std::runtime_error("Call to grid() failed.");
 
-template<typename Numeric>
-inline void pause(Numeric interval)
-{
-    detail::_interpreter::get();
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, PyFloat_FromDouble(interval));
+	inline void show(const bool block = true) {
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_pause, args);
-    if(!res) throw std::runtime_error("Call to pause() failed.");
+		PyObject *res;
+		if (block) {
+			res = PyObject_CallObject(detail::_interpreter::get().s_python_function_show, detail::_interpreter::get().s_python_empty_tuple);
+		} else {
+			PyObject *kwargs = PyDict_New();
+			PyDict_SetItemString(kwargs, "block", Py_False);
+			res = PyObject_Call(detail::_interpreter::get().s_python_function_show, detail::_interpreter::get().s_python_empty_tuple, kwargs);
+			Py_DECREF(kwargs);
+		}
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		if (!res) throw std::runtime_error("Call to show() failed.");
 
-inline void save(const std::string& filename)
-{
-    detail::_interpreter::get();
+		Py_DECREF(res);
+	}
 
-    PyObject* pyfilename = PyString_FromString(filename.c_str());
+	inline void close() {
+		detail::_interpreter::get();
 
-    PyObject* args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, pyfilename);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_close, detail::_interpreter::get().s_python_empty_tuple);
 
-    PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_save, args);
-    if (!res) throw std::runtime_error("Call to save() failed.");
+		if (!res) throw std::runtime_error("Call to close() failed.");
 
-    Py_DECREF(args);
-    Py_DECREF(res);
-}
+		Py_DECREF(res);
+	}
 
-inline void clf() {
-    detail::_interpreter::get();
+	inline void xkcd() {
+		detail::_interpreter::get();
 
-    PyObject *res = PyObject_CallObject(
-        detail::_interpreter::get().s_python_function_clf,
-        detail::_interpreter::get().s_python_empty_tuple);
+		PyObject *res;
+		PyObject *kwargs = PyDict_New();
 
-    if (!res) throw std::runtime_error("Call to clf() failed.");
+		res = PyObject_Call(detail::_interpreter::get().s_python_function_xkcd, detail::_interpreter::get().s_python_empty_tuple, kwargs);
 
-    Py_DECREF(res);
-}
+		Py_DECREF(kwargs);
 
-inline void ion() {
-    detail::_interpreter::get();
+		if (!res) throw std::runtime_error("Call to show() failed.");
 
-    PyObject *res = PyObject_CallObject(
-        detail::_interpreter::get().s_python_function_ion,
-        detail::_interpreter::get().s_python_empty_tuple);
+		Py_DECREF(res);
+	}
 
-    if (!res) throw std::runtime_error("Call to ion() failed.");
+	inline void draw() {
+		detail::_interpreter::get();
 
-    Py_DECREF(res);
-}
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_draw, detail::_interpreter::get().s_python_empty_tuple);
 
-inline std::vector<std::array<double, 2>> ginput(const int numClicks = 1, const std::map<std::string, std::string>& keywords = {})
-{
-    detail::_interpreter::get();
+		if (!res) throw std::runtime_error("Call to draw() failed.");
 
-    PyObject *args = PyTuple_New(1);
-    PyTuple_SetItem(args, 0, PyLong_FromLong(numClicks));
+		Py_DECREF(res);
+	}
 
-    // construct keyword args
-    PyObject* kwargs = PyDict_New();
-    for(std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it)
-    {
-        PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
-    }
+	template<typename Numeric>
+	inline void pause(Numeric interval) {
+		detail::_interpreter::get();
 
-    PyObject* res = PyObject_Call(
-        detail::_interpreter::get().s_python_function_ginput, args, kwargs);
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, PyFloat_FromDouble(interval));
 
-    Py_DECREF(kwargs);
-    Py_DECREF(args);
-    if (!res) throw std::runtime_error("Call to ginput() failed.");
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_pause, args);
+		if (!res) throw std::runtime_error("Call to pause() failed.");
 
-    const size_t len = PyList_Size(res);
-    std::vector<std::array<double, 2>> out;
-    out.reserve(len);
-    for (size_t i = 0; i < len; i++) {
-        PyObject *current = PyList_GetItem(res, i);
-        std::array<double, 2> position;
-        position[0] = PyFloat_AsDouble(PyTuple_GetItem(current, 0));
-        position[1] = PyFloat_AsDouble(PyTuple_GetItem(current, 1));
-        out.push_back(position);
-    }
-    Py_DECREF(res);
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
 
-    return out;
-}
+	inline void save(const std::string &filename) {
+		detail::_interpreter::get();
+
+		PyObject *pyfilename = PyString_FromString(filename.c_str());
+
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, pyfilename);
+
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_save, args);
+		if (!res) throw std::runtime_error("Call to save() failed.");
+
+		Py_DECREF(args);
+		Py_DECREF(res);
+	}
+
+	inline void clf() {
+		detail::_interpreter::get();
+
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_clf, detail::_interpreter::get().s_python_empty_tuple);
+
+		if (!res) throw std::runtime_error("Call to clf() failed.");
+
+		Py_DECREF(res);
+	}
+
+	inline void ion() {
+		detail::_interpreter::get();
+
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_ion, detail::_interpreter::get().s_python_empty_tuple);
+
+		if (!res) throw std::runtime_error("Call to ion() failed.");
+
+		Py_DECREF(res);
+	}
+
+	inline std::vector<std::array<double, 2>> ginput(const int numClicks = 1, const std::map<std::string, std::string> &keywords = { }) {
+		detail::_interpreter::get();
+
+		PyObject *args = PyTuple_New(1);
+		PyTuple_SetItem(args, 0, PyLong_FromLong(numClicks));
+
+		// construct keyword args
+		PyObject *kwargs = PyDict_New();
+		for (std::map<std::string, std::string>::const_iterator it = keywords.begin(); it != keywords.end(); ++it) {
+			PyDict_SetItemString(kwargs, it->first.c_str(), PyUnicode_FromString(it->second.c_str()));
+		}
+
+		PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_ginput, args, kwargs);
+
+		Py_DECREF(kwargs);
+		Py_DECREF(args);
+		if (!res) throw std::runtime_error("Call to ginput() failed.");
+
+		const size_t len = PyList_Size(res);
+		std::vector<std::array<double, 2>> out;
+		out.reserve(len);
+		for (size_t i = 0; i < len; i++) {
+			PyObject *current = PyList_GetItem(res, i);
+			std::array<double, 2> position;
+			position[0] = PyFloat_AsDouble(PyTuple_GetItem(current, 0));
+			position[1] = PyFloat_AsDouble(PyTuple_GetItem(current, 1));
+			out.push_back(position);
+		}
+		Py_DECREF(res);
+
+		return out;
+	}
 
 // Actually, is there any reason not to call this automatically for every plot?
-inline void tight_layout() {
-    detail::_interpreter::get();
+	inline void tight_layout() {
+		detail::_interpreter::get();
 
-    PyObject *res = PyObject_CallObject(
-        detail::_interpreter::get().s_python_function_tight_layout,
-        detail::_interpreter::get().s_python_empty_tuple);
+		PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_tight_layout, detail::_interpreter::get().s_python_empty_tuple);
 
-    if (!res) throw std::runtime_error("Call to tight_layout() failed.");
+		if (!res) throw std::runtime_error("Call to tight_layout() failed.");
 
-    Py_DECREF(res);
-}
+		Py_DECREF(res);
+	}
 
 // Support for variadic plot() and initializer lists:
 
-namespace detail {
+	namespace detail {
 
-template<typename T>
-using is_function = typename std::is_function<std::remove_pointer<std::remove_reference<T>>>::type;
+		template<typename T>
+		using is_function = typename std::is_function<std::remove_pointer<std::remove_reference<T>>>::type;
 
-template<bool obj, typename T>
-struct is_callable_impl;
+		template<bool obj, typename T>
+		struct is_callable_impl;
 
-template<typename T>
-struct is_callable_impl<false, T>
-{
-    typedef is_function<T> type;
-}; // a non-object is callable iff it is a function
+		template<typename T>
+		struct is_callable_impl<false, T> {
+				typedef is_function<T> type;
+		};
+		// a non-object is callable iff it is a function
 
-template<typename T>
-struct is_callable_impl<true, T>
-{
-    struct Fallback { void operator()(); };
-    struct Derived : T, Fallback { };
+		template<typename T>
+		struct is_callable_impl<true, T> {
+				struct Fallback {
+						void operator()();
+				};
+				struct Derived: T, Fallback {
+				};
 
-    template<typename U, U> struct Check;
+				template<typename U, U> struct Check;
 
-    template<typename U>
-    static std::true_type test( ... ); // use a variadic function to make sure (1) it accepts everything and (2) its always the worst match
+				template<typename U>
+				static std::true_type test(... ); // use a variadic function to make sure (1) it accepts everything and (2) its always the worst match
 
-    template<typename U>
-    static std::false_type test( Check<void(Fallback::*)(), &U::operator()>* );
+				template<typename U>
+				static std::false_type test(Check<void (Fallback::*)(), &U::operator()>*);
 
-public:
-    typedef decltype(test<Derived>(nullptr)) type;
-    typedef decltype(&Fallback::operator()) dtype;
-    static constexpr bool value = type::value;
-}; // an object is callable iff it defines operator()
+			public:
+				typedef decltype(test<Derived>(nullptr)) type;
+				typedef decltype(&Fallback::operator()) dtype;
+				static constexpr bool value = type::value;
+		};
+		// an object is callable iff it defines operator()
 
-template<typename T>
-struct is_callable
-{
-    // dispatch to is_callable_impl<true, T> or is_callable_impl<false, T> depending on whether T is of class type or not
-    typedef typename is_callable_impl<std::is_class<T>::value, T>::type type;
-};
+		template<typename T>
+		struct is_callable {
+				// dispatch to is_callable_impl<true, T> or is_callable_impl<false, T> depending on whether T is of class type or not
+				typedef typename is_callable_impl<std::is_class<T>::value, T>::type type;
+		};
 
-template<typename IsYDataCallable>
-struct plot_impl { };
+		template<typename IsYDataCallable>
+		struct plot_impl {
+		};
 
-template<>
-struct plot_impl<std::false_type>
-{
-    template<typename IterableX, typename IterableY>
-    bool operator()(const IterableX& x, const IterableY& y, const std::string& format)
-    {
-        // 2-phase lookup for distance, begin, end
-        using std::distance;
-        using std::begin;
-        using std::end;
+		template<>
+		struct plot_impl<std::false_type> {
+				template<typename IterableX, typename IterableY>
+				bool operator()(const IterableX &x, const IterableY &y, const std::string &format) {
+					// 2-phase lookup for distance, begin, end
+					using std::distance;
+					using std::begin;
+					using std::end;
 
-        auto xs = distance(begin(x), end(x));
-        auto ys = distance(begin(y), end(y));
-        assert(xs == ys && "x and y data must have the same number of elements!");
+					auto xs = distance(begin(x), end(x));
+					auto ys = distance(begin(y), end(y));
+					assert(xs == ys && "x and y data must have the same number of elements!");
 
-        PyObject* xlist = PyList_New(xs);
-        PyObject* ylist = PyList_New(ys);
-        PyObject* pystring = PyString_FromString(format.c_str());
+					PyObject *xlist = PyList_New(xs);
+					PyObject *ylist = PyList_New(ys);
+					PyObject *pystring = PyString_FromString(format.c_str());
 
-        auto itx = begin(x), ity = begin(y);
-        for(size_t i = 0; i < xs; ++i) {
-            PyList_SetItem(xlist, i, PyFloat_FromDouble(*itx++));
-            PyList_SetItem(ylist, i, PyFloat_FromDouble(*ity++));
-        }
+					auto itx = begin(x), ity = begin(y);
+					for (size_t i = 0; i < xs; ++i) {
+						PyList_SetItem(xlist, i, PyFloat_FromDouble(*itx++));
+						PyList_SetItem(ylist, i, PyFloat_FromDouble(*ity++));
+					}
 
-        PyObject* plot_args = PyTuple_New(3);
-        PyTuple_SetItem(plot_args, 0, xlist);
-        PyTuple_SetItem(plot_args, 1, ylist);
-        PyTuple_SetItem(plot_args, 2, pystring);
+					PyObject *plot_args = PyTuple_New(3);
+					PyTuple_SetItem(plot_args, 0, xlist);
+					PyTuple_SetItem(plot_args, 1, ylist);
+					PyTuple_SetItem(plot_args, 2, pystring);
 
-        PyObject* res = PyObject_CallObject(detail::_interpreter::get().s_python_function_plot, plot_args);
+					PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_plot, plot_args);
 
-        Py_DECREF(plot_args);
-        if(res) Py_DECREF(res);
+					Py_DECREF(plot_args);
+					if (res) Py_DECREF(res);
 
-        return res;
-    }
-};
+					return res;
+				}
+		};
 
-template<>
-struct plot_impl<std::true_type>
-{
-    template<typename Iterable, typename Callable>
-    bool operator()(const Iterable& ticks, const Callable& f, const std::string& format)
-    {
-        if(begin(ticks) == end(ticks)) return true;
+		template<>
+		struct plot_impl<std::true_type> {
+				template<typename Iterable, typename Callable>
+				bool operator()(const Iterable &ticks, const Callable &f, const std::string &format) {
+					if (begin(ticks) == end(ticks)) return true;
 
-        // We could use additional meta-programming to deduce the correct element type of y,
-        // but all values have to be convertible to double anyways
-        std::vector<double> y;
-        for(auto x : ticks) y.push_back(f(x));
-        return plot_impl<std::false_type>()(ticks,y,format);
-    }
-};
+					// We could use additional meta-programming to deduce the correct element type of y,
+					// but all values have to be convertible to double anyways
+					std::vector<double> y;
+					for (auto x : ticks)
+						y.push_back(f(x));
+					return plot_impl<std::false_type>()(ticks, y, format);
+				}
+		};
 
-} // end namespace detail
+	} // end namespace detail
 
 // recursion stop for the above
-template<typename... Args>
-bool plot() { return true; }
+	template<typename ... Args>
+	bool plot() {
+		return true;
+	}
 
-template<typename A, typename B, typename... Args>
-bool plot(const A& a, const B& b, const std::string& format, Args... args)
-{
-    return detail::plot_impl<typename detail::is_callable<B>::type>()(a,b,format) && plot(args...);
-}
+	template<typename A, typename B, typename ... Args>
+	bool plot(const A &a, const B &b, const std::string &format, Args ... args) {
+		return detail::plot_impl<typename detail::is_callable<B>::type>()(a, b, format) && plot(args...);
+	}
 
-/*
- * This group of plot() functions is needed to support initializer lists, i.e. calling
- *    plot( {1,2,3,4} )
- */
-inline bool plot(const std::vector<double>& x, const std::vector<double>& y, const std::string& format = "") {
-    return plot<double,double>(x,y,format);
-}
+	/*
+	 * This group of plot() functions is needed to support initializer lists, i.e. calling
+	 *    plot( {1,2,3,4} )
+	 */
+	inline bool plot(const std::vector<double> &x, const std::vector<double> &y, const std::string &format = "") {
+		return plot<double, double>(x, y, format);
+	}
 
-inline bool plot(const std::vector<double>& y, const std::string& format = "") {
-    return plot<double>(y,format);
-}
+	inline bool plot(const std::vector<double> &y, const std::string &format = "") {
+		return plot<double>(y, format);
+	}
 
-inline bool plot(const std::vector<double>& x, const std::vector<double>& y, const std::map<std::string, std::string>& keywords) {
-    return plot<double>(x,y,keywords);
-}
+	inline bool plot(const std::vector<double> &x, const std::vector<double> &y, const std::map<std::string, std::string> &keywords) {
+		return plot<double>(x, y, keywords);
+	}
 
-/*
- * This class allows dynamic plots, ie changing the plotted data without clearing and re-plotting
- */
-class Plot
-{
-public:
-    // default initialization with plot label, some data and format
-    template<typename Numeric>
-    Plot(const std::string& name, const std::vector<Numeric>& x, const std::vector<Numeric>& y, const std::string& format = "") {
-        detail::_interpreter::get();
+	/*
+	 * This class allows dynamic plots, ie changing the plotted data without clearing and re-plotting
+	 */
+	class Plot {
+		public:
+			// default initialization with plot label, some data and format
+			template<typename Numeric>
+			Plot(const std::string &name, const std::vector<Numeric> &x, const std::vector<Numeric> &y, const std::string &format = "") {
+				detail::_interpreter::get();
 
-        assert(x.size() == y.size());
+				assert(x.size() == y.size());
 
-        PyObject* kwargs = PyDict_New();
-        if(name != "")
-            PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
+				PyObject *kwargs = PyDict_New();
+				if (name != "") PyDict_SetItemString(kwargs, "label", PyString_FromString(name.c_str()));
 
-        PyObject* xarray = detail::get_array(x);
-        PyObject* yarray = detail::get_array(y);
+				PyObject *xarray = detail::get_array(x);
+				PyObject *yarray = detail::get_array(y);
 
-        PyObject* pystring = PyString_FromString(format.c_str());
+				PyObject *pystring = PyString_FromString(format.c_str());
 
-        PyObject* plot_args = PyTuple_New(3);
-        PyTuple_SetItem(plot_args, 0, xarray);
-        PyTuple_SetItem(plot_args, 1, yarray);
-        PyTuple_SetItem(plot_args, 2, pystring);
+				PyObject *plot_args = PyTuple_New(3);
+				PyTuple_SetItem(plot_args, 0, xarray);
+				PyTuple_SetItem(plot_args, 1, yarray);
+				PyTuple_SetItem(plot_args, 2, pystring);
 
-        PyObject* res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
+				PyObject *res = PyObject_Call(detail::_interpreter::get().s_python_function_plot, plot_args, kwargs);
 
-        Py_DECREF(kwargs);
-        Py_DECREF(plot_args);
+				Py_DECREF(kwargs);
+				Py_DECREF(plot_args);
 
-        if(res)
-        {
-            line= PyList_GetItem(res, 0);
+				if (res) {
+					line = PyList_GetItem(res, 0);
 
-            if(line)
-                set_data_fct = PyObject_GetAttrString(line,"set_data");
-            else
-                Py_DECREF(line);
-            Py_DECREF(res);
-        }
-    }
+					if (line) set_data_fct = PyObject_GetAttrString(line, "set_data");
+					else Py_DECREF(line);
+					Py_DECREF(res);
+				}
+			}
 
-    // shorter initialization with name or format only
-    // basically calls line, = plot([], [])
-    Plot(const std::string& name = "", const std::string& format = "")
-        : Plot(name, std::vector<double>(), std::vector<double>(), format) {}
+			// shorter initialization with name or format only
+			// basically calls line, = plot([], [])
+			Plot(const std::string &name = "", const std::string &format = "") :
+					Plot(name, std::vector<double>(), std::vector<double>(), format) {
+			}
 
-    template<typename Numeric>
-    bool update(const std::vector<Numeric>& x, const std::vector<Numeric>& y) {
-        assert(x.size() == y.size());
-        if(set_data_fct)
-        {
-            PyObject* xarray = detail::get_array(x);
-            PyObject* yarray = detail::get_array(y);
+			template<typename Numeric>
+			bool update(const std::vector<Numeric> &x, const std::vector<Numeric> &y) {
+				assert(x.size() == y.size());
+				if (set_data_fct) {
+					PyObject *xarray = detail::get_array(x);
+					PyObject *yarray = detail::get_array(y);
 
-            PyObject* plot_args = PyTuple_New(2);
-            PyTuple_SetItem(plot_args, 0, xarray);
-            PyTuple_SetItem(plot_args, 1, yarray);
+					PyObject *plot_args = PyTuple_New(2);
+					PyTuple_SetItem(plot_args, 0, xarray);
+					PyTuple_SetItem(plot_args, 1, yarray);
 
-            PyObject* res = PyObject_CallObject(set_data_fct, plot_args);
-            if (res) Py_DECREF(res);
-            return res;
-        }
-        return false;
-    }
+					PyObject *res = PyObject_CallObject(set_data_fct, plot_args);
+					if (res) Py_DECREF(res);
+					return res;
+				}
+				return false;
+			}
 
-    // clears the plot but keep it available
-    bool clear() {
-        return update(std::vector<double>(), std::vector<double>());
-    }
+			// clears the plot but keep it available
+			bool clear() {
+				return update(std::vector<double>(), std::vector<double>());
+			}
 
-    // definitely remove this line
-    void remove() {
-        if(line)
-        {
-            auto remove_fct = PyObject_GetAttrString(line,"remove");
-            PyObject* args = PyTuple_New(0);
-            PyObject* res = PyObject_CallObject(remove_fct, args);
-            if (res) Py_DECREF(res);
-        }
-        decref();
-    }
+			// definitely remove this line
+			void remove() {
+				if (line) {
+					auto remove_fct = PyObject_GetAttrString(line, "remove");
+					PyObject *args = PyTuple_New(0);
+					PyObject *res = PyObject_CallObject(remove_fct, args);
+					if (res) Py_DECREF(res);
+				}
+				decref();
+			}
 
-    ~Plot() {
-        decref();
-    }
-private:
+			~Plot() {
+				decref();
+			}
+		private:
 
-    void decref() {
-        if(line)
-            Py_DECREF(line);
-        if(set_data_fct)
-            Py_DECREF(set_data_fct);
-    }
+			void decref() {
+				if (line) Py_DECREF(line);
+				if (set_data_fct) Py_DECREF(set_data_fct);
+			}
 
-
-    PyObject* line = nullptr;
-    PyObject* set_data_fct = nullptr;
-};
+			PyObject *line = nullptr;
+			PyObject *set_data_fct = nullptr;
+	};
 
 } // end namespace matplotlibcpp


### PR DESCRIPTION
When adding a submodule in an c/c++ project the examples get in the way
defining the main function again. Now this will not happen.