### PR TITLE
Suggestion: Give more multithreading flexibility on destructor

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -107,7 +107,17 @@ struct _interpreter {
        */
 
     static _interpreter& get() {
+        return interkeeper(false);
+    }
+
+    static _interpreter& kill() {
+        return interkeeper(true);
+    }
+
+    static _interpreter& interkeeper(bool should_kill) {
         static _interpreter ctx;
+        if (should_kill)
+            ctx.~_interpreter();
         return ctx;
     }
 


### PR DESCRIPTION
The Python interpreter can be constructed by any thread while the destructor is always the main thread. This can lead in some errors with the Python side of things, where some objects want the thread which constructed them to also destroy them. By adding this 'kill' function, a developer can use your library (btw gj! 👍 ) with `std::thread` in order to create a plot async -aka without blocking the main thread- and then close the plot and 'kill' Python interpreter afterwards, without waiting the program to end or having destructor errors.

Doing this in order to showcase this more. Small change but not that polished. Let me know about your opinion first and we can fix it 😃.
Thank you for your time and this great library ❤️