### PR TITLE
Fix issue lava/matplotlib-cpp#124

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -153,6 +153,11 @@ private:
         Py_SetProgramName(name);
         Py_Initialize();
 
+        wchar_t const *dummy_args[] = {L"Python", NULL};  // const is needed because literals must not be modified
+        wchar_t const **argv = dummy_args;
+        int             argc = sizeof(dummy_args)/sizeof(dummy_args[0])-1;
+        PySys_SetArgv(argc, const_cast<wchar_t **>(argv));
+
 #ifndef WITHOUT_NUMPY
         import_numpy(); // initialize numpy C-API
 #endif


### PR DESCRIPTION
This fix has been tested on Debian Buster with Python 3.7.3 and should not involve any regression I think (I hope).

After investigation, I found the problem was clearly the same situation explained in this post : https://stackoverflow.com/questions/42537291/embedding-python-with-c