### PR TITLE
Added 'set_aspect' and set_aspect_equal function

### DIFF
--- a/examples/modern.cpp
+++ b/examples/modern.cpp
@@ -24,6 +24,9 @@ int main()
 	// y must either be callable (providing operator() const) or iterable. 
 	plt::plot(x, y, "r-", x, [](double d) { return 12.5+abs(sin(d)); }, "k-");
 
+	//plt::set_aspect(0.5);
+	plt::set_aspect_equal();
+
 
 	// show plots
 	plt::show();

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -1858,6 +1858,62 @@ inline void legend(const std::map<std::string, std::string>& keywords)
 }
 
 template<typename Numeric>
+inline void set_aspect(Numeric ratio)
+{
+    detail::_interpreter::get();
+
+    PyObject* args = PyTuple_New(1);
+    PyTuple_SetItem(args, 0, PyFloat_FromDouble(ratio));
+    PyObject* kwargs = PyDict_New();
+
+    PyObject *ax =
+    PyObject_CallObject(detail::_interpreter::get().s_python_function_gca,
+      detail::_interpreter::get().s_python_empty_tuple);
+    if (!ax) throw std::runtime_error("Call to gca() failed.");
+    Py_INCREF(ax);
+
+    PyObject *set_aspect = PyObject_GetAttrString(ax, "set_aspect");
+    if (!set_aspect) throw std::runtime_error("Attribute set_aspect not found.");
+    Py_INCREF(set_aspect);
+
+    PyObject *res = PyObject_Call(set_aspect, args, kwargs);
+    if (!res) throw std::runtime_error("Call to set_aspect() failed.");
+    Py_DECREF(set_aspect);
+
+    Py_DECREF(ax);
+    Py_DECREF(args);
+    Py_DECREF(kwargs);
+}
+
+inline void set_aspect_equal()
+{
+    // expect ratio == "equal". Leaving error handling to matplotlib.
+    detail::_interpreter::get();
+
+    PyObject* args = PyTuple_New(1);
+    PyTuple_SetItem(args, 0, PyString_FromString("equal"));
+    PyObject* kwargs = PyDict_New();
+
+    PyObject *ax =
+    PyObject_CallObject(detail::_interpreter::get().s_python_function_gca,
+      detail::_interpreter::get().s_python_empty_tuple);
+    if (!ax) throw std::runtime_error("Call to gca() failed.");
+    Py_INCREF(ax);
+
+    PyObject *set_aspect = PyObject_GetAttrString(ax, "set_aspect");
+    if (!set_aspect) throw std::runtime_error("Attribute set_aspect not found.");
+    Py_INCREF(set_aspect);
+
+    PyObject *res = PyObject_Call(set_aspect, args, kwargs);
+    if (!res) throw std::runtime_error("Call to set_aspect() failed.");
+    Py_DECREF(set_aspect);
+
+    Py_DECREF(ax);
+    Py_DECREF(args);
+    Py_DECREF(kwargs);
+}
+
+template<typename Numeric>
 void ylim(Numeric left, Numeric right)
 {
     detail::_interpreter::get();


### PR DESCRIPTION
Added a "set_aspect(Numeric ratio)" and "set_aspect_equal()" function.

Nothing too fancy. Respectively calls : 
 
`matplotlib.pyplot.gca().set_aspect(ratio)`

and

`matplotlib.pyplot.gca().set_aspect('equal')`

I like the simplicity of your wrapper. Keep up the good work :)
