### PR TITLE
Enable cmake definition matplotlib_cpp_INCLUDE_DIRS

### DIFF
--- a/cmake/matplotlib_cppConfig.cmake.in
+++ b/cmake/matplotlib_cppConfig.cmake.in
@@ -4,4 +4,7 @@ if(NOT TARGET matplotlib_cpp::matplotlib_cpp)
   find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
   find_package(Python3 COMPONENTS NumPy)
   include("${matplotlib_cpp_CMAKE_DIR}/matplotlib_cppTargets.cmake")
+
+  get_target_property(matplotlib_cpp_INCLUDE_DIRS matplotlib_cpp::matplotlib_cpp INTERFACE_INCLUDE_DIRECTORIES)
+
 endif()


### PR DESCRIPTION
Some users who install matplotlib-cpp in non-public directory should be happy.