### PR TITLE
Fix compiling errors on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ int main() {
 A more comprehensive example:
 ```cpp
 #include "matplotlibcpp.h"
-#include <cmath>
-
 namespace plt = matplotlibcpp;
 
 int main()
@@ -67,9 +65,7 @@ int main()
 
 Alternatively, matplotlib-cpp also supports some C++11-powered syntactic sugar:
 ```cpp
-#include <cmath>
 #include "matplotlibcpp.h"
-
 using namespace std;
 namespace plt = matplotlibcpp;
 
@@ -104,8 +100,6 @@ Or some *funny-looking xkcd-styled* example:
 ```cpp
 #include "matplotlibcpp.h"
 #include <vector>
-#include <cmath>
-
 namespace plt = matplotlibcpp;
 
 int main() {

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -350,10 +350,12 @@ template <> struct select_npy_type<uint64_t> { const static NPY_TYPES type = NPY
 
 // Sanity checks; comment them out or change the numpy type below if you're compiling on
 // a platform where they don't apply
+#ifndef _WIN32
 static_assert(sizeof(long long) == 8);
 template <> struct select_npy_type<long long> { const static NPY_TYPES type = NPY_INT64; };
 static_assert(sizeof(unsigned long long) == 8);
 template <> struct select_npy_type<unsigned long long> { const static NPY_TYPES type = NPY_UINT64; };
+#endif
 
 template<typename Numeric>
 PyObject* get_array(const std::vector<Numeric>& v)

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -1817,7 +1817,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
+    for(size_t i = 0; i < x.size(); ++i) x.at(i) = static_cast<Numeric>(i);
     return plot(x,y,format);
 }
 
@@ -1825,7 +1825,7 @@ template<typename Numeric>
 bool plot(const std::vector<Numeric>& y, const std::map<std::string, std::string>& keywords)
 {
     std::vector<Numeric> x(y.size());
-    for(size_t i=0; i<x.size(); ++i) x.at(i) = i;
+    for(size_t i = 0; i < x.size(); ++i) x.at(i) = static_cast<Numeric>(i);
     return plot(x,y,keywords);
 }
 
@@ -1833,7 +1833,7 @@ template<typename Numeric>
 bool stem(const std::vector<Numeric>& y, const std::string& format = "")
 {
     std::vector<Numeric> x(y.size());
-    for (size_t i = 0; i < x.size(); ++i) x.at(i) = i;
+    for(size_t i = 0; i < x.size(); ++i) x.at(i) = static_cast<Numeric>(i);
     return stem(x, y, format);
 }
 

--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Define math constants for Visual Studio https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+#if defined(_MSC_VER)
+#define _USE_MATH_DEFINES
+#endif
+
 // Python headers must be included before any system headers, since
 // they define _POSIX_C_SOURCE
 #include <Python.h>


### PR DESCRIPTION
Compiling code from some examples results in compiling errors on **64-bit Windows** using **Visual Studio 2019**.
This request fixes these errors and improves the **Windows** experience of **matplotlib-cpp**.

Note that compiling in **DEBUG** configuration still causes some runtime exceptions, but this is just a comment and this request doesn't deal with fixing it
```
Traceback (most recent call last):
  File "Python39\site-packages\numpy\core\__init__.py", line 22, in <module>
    from . import multiarray
  File "Python39\site-packages\numpy\core\multiarray.py", line 12, in <module>
    from . import overrides
  File "Python39\site-packages\numpy\core\overrides.py", line 7, in <module>
    from numpy.core._multiarray_umath import (
ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "Python39\site-packages\numpy\__init__.py", line 145, in <module>
    from . import core
  File "Python39\site-packages\numpy\core\__init__.py", line 48, in <module>
    raise ImportError(msg)
ImportError:

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python3.9 from "build.exe"
  * The NumPy version is: "1.20.3"

and make sure that they are the versions you expect.
Please carefully study the documentation linked above for further help.

Original error was: No module named 'numpy.core._multiarray_umath'

Traceback (most recent call last):
  File "Python39\site-packages\numpy\core\__init__.py", line 22, in <module>
    from . import multiarray
  File "Python39\site-packages\numpy\core\multiarray.py", line 12, in <module>
    from . import overrides
  File "Python39\site-packages\numpy\core\overrides.py", line 7, in <module>
    from numpy.core._multiarray_umath import (
ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "Python39\lib\site-packages\matplotlib\__init__.py", line 107, in <module>
    from . import _api, cbook, docstring, rcsetup
  File "Python39\lib\site-packages\matplotlib\cbook\__init__.py", line 28, in <module>
    import numpy as np
  File "Python39\site-packages\numpy\__init__.py", line 145, in <module>
    from . import core
  File "Python39\site-packages\numpy\core\__init__.py", line 48, in <module>
    raise ImportError(msg)
ImportError:

IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!

Importing the numpy C-extensions failed. This error can happen for
many reasons, often due to issues with your setup or how NumPy was
installed.

We have compiled some common reasons and troubleshooting tips at:

    https://numpy.org/devdocs/user/troubleshooting-importerror.html

Please note and check the following:

  * The Python version is: Python3.9 from "build.exe"
  * The NumPy version is: "1.20.3"

and make sure that they are the versions you expect.
Please carefully study the documentation linked above for further help.

Original error was: No module named 'numpy.core._multiarray_umath'
```