### PR TITLE
Support CMake version less than 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,28 @@ target_compile_features(matplotlib_cpp INTERFACE
   cxx_std_11
 )
 # TODO: Use `Development.Embed` component when requiring cmake >= 3.18
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-target_link_libraries(matplotlib_cpp INTERFACE
-  Python3::Python
-  Python3::Module
-)
-find_package(Python3 COMPONENTS NumPy)
-if(Python3_NumPy_FOUND)
+if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
+  find_package(PythonLibs 3 REQUIRED)
+  include_directories(
+    ${PYTHON_INCLUDE_DIRS}
+  )
   target_link_libraries(matplotlib_cpp INTERFACE
-    Python3::NumPy
+    ${PYTHON_LIBRARIES}
   )
 else()
-  target_compile_definitions(matplotlib_cpp INTERFACE WITHOUT_NUMPY)
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  target_link_libraries(matplotlib_cpp INTERFACE
+    Python3::Python
+    Python3::Module
+  )
+  find_package(Python3 COMPONENTS NumPy)
+  if(Python3_NumPy_FOUND)
+    target_link_libraries(matplotlib_cpp INTERFACE
+      Python3::NumPy
+    )
+  else()
+    target_compile_definitions(matplotlib_cpp INTERFACE WITHOUT_NUMPY)
+  endif()
 endif()
 install(
   TARGETS matplotlib_cpp


### PR DESCRIPTION
FindPython isn't available prior to CMake 3.12. 
Linux distros still commonly in use bundle old versions of cmake. Ubuntu 18.04 as an example bundles 3.10.
So why don't we use PythonLibs for CMakde under version 3.12?