### PR TITLE
Support CMake versions 3.8-3.12.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,30 +9,38 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/${PACKAGE_NAME}/cmake)
 # Library target
 add_library(matplotlib_cpp INTERFACE)
 target_include_directories(matplotlib_cpp
-  INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/examples>
-    $<INSTALL_INTERFACE:include>
-)
+                           INTERFACE
+                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/examples>
+                           $<INSTALL_INTERFACE:include>
+                           )
 target_compile_features(matplotlib_cpp INTERFACE
-  cxx_std_11
-)
+                        cxx_std_11
+                        )
 # TODO: Use `Development.Embed` component when requiring cmake >= 3.18
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-target_link_libraries(matplotlib_cpp INTERFACE
-  Python3::Python
-  Python3::Module
-)
-find_package(Python3 COMPONENTS NumPy)
-if(Python3_NumPy_FOUND)
-  target_link_libraries(matplotlib_cpp INTERFACE
-    Python3::NumPy
-  )
+if(${CMAKE_VERSION} VERSION_LESS "3.12.4")
+  find_package(PythonLibs 3.0 COMPONENTS Interpreter Development NumPy)
+  target_link_libraries(matplotlib_cpp INTERFACE ${PYTHON_LIBRARIES})
+  target_include_directories(matplotlib_cpp INTERFACE ${PYTHON_INCLUDE_DIRS})
 else()
-  target_compile_definitions(matplotlib_cpp INTERFACE WITHOUT_NUMPY)
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  find_package(Python3 COMPONENTS NumPy)
+  if(Python3_NumPy_FOUND)
+    target_link_libraries(matplotlib_cpp INTERFACE
+                          Python3::NumPy
+                          )
+  else()
+    target_compile_definitions(matplotlib_cpp INTERFACE WITHOUT_NUMPY)
+  endif()
+
+  target_link_libraries(matplotlib_cpp INTERFACE
+                        Python3::Python
+                        Python3::Module
+                        )
 endif()
+
 install(
-  TARGETS matplotlib_cpp
-  EXPORT install_targets
+        TARGETS matplotlib_cpp
+        EXPORT install_targets
 )
 
 
@@ -105,29 +113,29 @@ endif()
 
 # Install headers
 install(FILES
-  "${PROJECT_SOURCE_DIR}/matplotlibcpp.h"
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        "${PROJECT_SOURCE_DIR}/matplotlibcpp.h"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 
 # Install targets file
 install(EXPORT install_targets
-  FILE
-    ${PACKAGE_NAME}Targets.cmake
-  NAMESPACE
-    ${PACKAGE_NAME}::
-  DESTINATION
-    ${INSTALL_CONFIGDIR}
-)
+        FILE
+        ${PACKAGE_NAME}Targets.cmake
+        NAMESPACE
+        ${PACKAGE_NAME}::
+        DESTINATION
+        ${INSTALL_CONFIGDIR}
+        )
 
 
 # Install matplotlib_cppConfig.cmake
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PACKAGE_NAME}Config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake
-  INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PACKAGE_NAME}Config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake
+        INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
 )
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake
-  DESTINATION ${INSTALL_CONFIGDIR}
-)
+        ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake
+        DESTINATION ${INSTALL_CONFIGDIR}
+        )


### PR DESCRIPTION
The repository currently does not support CMake versions 3.8 to 3.12.4 because the FindPython3.cmake module was not added until 3.12.4 and the minimum CMake version for the project is set to 3.8. This PR adds the necessary CMake code to still correctly compile and link to the relevant Python libraries. 