### PR TITLE
Fix Debug runtime error Under the win32 platform.

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -2,7 +2,15 @@
 
 // Python headers must be included before any system headers, since
 // they define _POSIX_C_SOURCE
+// Under the win32 platform and debug, python cannot find the matplotlib package
+// normally. It is recommended that the debug definition include python.h is not applicable in this case.
+#ifdef _DEBUG && defined(MS_WIN32)
+#undef _DEBUG
 #include <Python.h>
+#define _DEBUG
+#else
+#include <Python.h>
+#endif
 
 #include <vector>
 #include <map>


### PR DESCRIPTION
Under the win32 platform and debug, python cannot find the matplotlib package normally. It is recommended that the debug definition include python.h is not applicable in this case.