### PR TITLE
Fix CMake library include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/${PACKAGE_NAME}/cmake)
 add_library(matplotlib_cpp INTERFACE)
 target_include_directories(matplotlib_cpp
   INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/examples>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 target_compile_features(matplotlib_cpp INTERFACE


### PR DESCRIPTION
Fixes two things:
- `matplotib_cpp` target requires `$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>` to be used with `add_subdirectory` so that `matplotlibcpp.h` can be included seamlessly
- There are no headers within the `examples` subdirectory, therefore the `$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/examples>` is useless