### PR TITLE
solved PyType_Slot *slots; bug in Python.h include command

### DIFF
--- a/matplotlibcpp.h
+++ b/matplotlibcpp.h
@@ -2,7 +2,10 @@
 
 // Python headers must be included before any system headers, since
 // they define _POSIX_C_SOURCE
-#include <Python.h>
+#pragma push_macro("slots")
+#undef slots
+#include "Python.h"
+#pragma pop_macro("slots")
 
 #include <vector>
 #include <map>


### PR DESCRIPTION
Compiling a project using this library sometimes throws the following error: "expected unqualified-id before ‘;’ token
  190 |     PyType_Slot *slots; " 
Since Qt uses slots as a reserved keyword there is a clash with the declaration of the slots member of the PyType_Slot struct in Python.h. To avoid the conflict regarding 'slots', without the need for deactivating the keywords signals/slots/emit (which may be undesirable for large Qt projects), the code edit locally "parks" the offending keyword while Python.h is included, and then reassigns it. 