### PR TITLE
fix typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You can download and install matplotlib-cpp using the [vcpkg](https://github.com
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    vcpkg install matplotlib-cpp
+    ./vcpkg install matplotlib-cpp
   
 The matplotlib-cpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 


### PR DESCRIPTION
Fix a typo in the readme.
In the section "Vcpkg", replace "vcpkg install matplotlib-cpp" with "./vcpkg install matplotlib-cpp".